### PR TITLE
if ldap auth fails, then show coaching message with logon form. 

### DIFF
--- a/askbot/deps/django_authopenid/views.py
+++ b/askbot/deps/django_authopenid/views.py
@@ -317,6 +317,8 @@ def signin(
                                     login_provider_name = ldap_provider_name,
                                     redirect_url = next_url
                                 )
+                    else:
+                        login_form.set_password_login_error() 
                 else:
                     if password_action == 'login':
                         user = authenticate(


### PR DESCRIPTION
happy path works, but this pull request simply adds an else block in case the ldap authentication failed.
