### PR TITLE
moved error handler to separate middleware. it was conflicting with other

### DIFF
--- a/askbot/middleware/pagesize.py
+++ b/askbot/middleware/pagesize.py
@@ -36,6 +36,8 @@ class QuestionsPageSizeMiddleware(object):
                 user.save()
         # put page_size into session
         request.session["page_size"] = page_size
+        
+class ErrorExceptionMiddleware(object):
 
     def process_exception(self, request, exception):
         #todo: move this to separate middleware


### PR DESCRIPTION
moved askbot page size error handler to separate middleware. this conflicts with other error handlers in applications that depended on askbot. it does require an additional line to be added to the MIDDLEWARE django settings, so docs need to be updated to reflect as well.
