### PR TITLE
Disable anonymous user greatings

### DIFF
--- a/askbot/conf/site_settings.py
+++ b/askbot/conf/site_settings.py
@@ -70,6 +70,15 @@ settings.register(
 )
 
 settings.register(
+    livesettings.BooleanValue(
+        QA_SITE_SETTINGS,
+        'GREETING_FOR_ANON_USER_ON',
+        default = True,
+        description = _('Check to enable greeting for anonymous user')
+   )
+)
+
+settings.register(
     livesettings.StringValue(
         QA_SITE_SETTINGS,
         'GREETING_FOR_ANONYMOUS_USER',

--- a/askbot/middleware/anon_user.py
+++ b/askbot/middleware/anon_user.py
@@ -43,7 +43,8 @@ class ConnectToSessionMessagesMiddleware(object):
 
             #also set the first greeting one time per session only
             if 'greeting_set' not in request.session and \
-                    'askbot_visitor' not in request.COOKIES:
+                    'askbot_visitor' not in request.COOKIES and \
+			askbot_settings.GREETING_FOR_ANON_USER_ON:
                 request.session['greeting_set'] = True
                 msg = askbot_settings.GREETING_FOR_ANONYMOUS_USER
                 request.user.message_set.create(message=msg)


### PR DESCRIPTION
It would be useful to completely disable the anonymous user greeting.

This adds a checkbox that is set to True by default, and unticking this will disable the greeting notification.
