### PR TITLE
Autolink keyterms: Patterns Failed to match because of special char's like \r and \r

### DIFF
--- a/askbot/utils/markup.py
+++ b/askbot/utils/markup.py
@@ -37,7 +37,7 @@ def get_parser():
         for item in pairs:
             LINK_PATTERNS.append(
                 (
-                    re.compile(item[0]),
+                    re.compile(item[0].strip()),
                     item[1].strip()
                 )
             )


### PR DESCRIPTION
- Autolinking keyterms: uncleaned regex included special characters like \r \n. This caused matches to fail
- Add: strip() to the regex before compiling them into regex object
