### PR TITLE
Feature 110, Now has test coverage and User is imported from askbot instead of django.auth

### DIFF
--- a/askbot/management/commands/migrate_user_account.py
+++ b/askbot/management/commands/migrate_user_account.py
@@ -1,6 +1,6 @@
 from django.core.management.base import CommandError, BaseCommand
 from django.db.models import get_model
-from django.contrib.auth.models import User
+from askbot.models import User
 
 
 class Command(BaseCommand):

--- a/askbot/tests/management_command_tests.py
+++ b/askbot/tests/management_command_tests.py
@@ -26,3 +26,26 @@ class ManagementCommandTests(AskbotTestCase):
         #try to log in
         user = auth.authenticate(username = username, password = password)
         self.assertTrue(user is not None)
+
+    def test_migrate_user_account(self):
+      """Verify a users account can be transfered to another user"""
+      # Create a new user and add some random related objects
+      user_one = self.create_user()
+      question = self.post_question(user=user_one)
+      comment = self.post_comment(user=user_one, parent_post=question)
+      number_of_gold = 50
+      user_one.gold = number_of_gold 
+      reputation = 20
+      user_one.reputation = reputation 
+      user_one.save()
+      # Create a second user and transfer all objects from 'user_one' to 'user_two'
+      user_two = self.create_user(username='unique')
+      management.call_command('migrate_user_account', user_one.id, user_two.id)
+      # Check that the first user was deleted
+      self.assertEqual(models.User.objects.filter(pk=user_one.id).count(), 0)
+      # Explicitly check that the values assigned to user_one are now user_two's
+      self.assertEqual(user_two.questions.filter(pk=question.id).count(), 1)  
+      self.assertEqual(user_two.comments.filter(pk=comment.id).count(), 1)  
+      user_two = models.User.objects.get(pk=2)
+      self.assertEqual(user_two.gold, number_of_gold) 
+      self.assertEqual(user_two.reputation, reputation)


### PR DESCRIPTION
I got excited when I saw your test helper and had to write a test.

Feature 110

This command transfers ownership of all related objects from one user id to another user id.
It will then delete the from_user_id.

It does not transfer profile specific information such as:
questions_per_page
real_name
website
location
country
show_country
date_of_birth
about
interesting_tags
ignored_tags
email_tag_filter_strategy
display_tag_filter_strategy
new_response_count
seen_response_count
consecutive_days_visit_count

It could easily combine this information if required, or provide output such as a settable verbosity level on each item it transfers.
