### PR TITLE
login link uses next= to redirect users to askbot page after login 

### DIFF
--- a/askbot/skins/default/templates/widgets/user_navigation.html
+++ b/askbot/skins/default/templates/widgets/user_navigation.html
@@ -11,5 +11,5 @@
 {% endif %}
 
 {% if request.user.is_authenticated() and request.user.is_administrator() %}
-    <a href="{% url site_settings %}">{% trans %}settings{% endtrans %}</a>
+    <a href="{% url site_settings %}?next={{ settings.ASKBOT_URL }}">{% trans %}settings{% endtrans %}</a>
 {% endif %}


### PR DESCRIPTION
should work with django login, not sure whether this will be compatible with custom authentication / login systems?
