### PR TITLE
Add a new setting "SHARING_SUFFIX_TEXT" that can be filled with

### DIFF
--- a/askbot/conf/social_sharing.py
+++ b/askbot/conf/social_sharing.py
@@ -3,7 +3,7 @@ Social sharing settings
 """
 from askbot.conf.settings_wrapper import settings
 from askbot.conf.super_groups import EXTERNAL_SERVICES
-from askbot.deps.livesettings import ConfigurationGroup, BooleanValue
+from askbot.deps.livesettings import ConfigurationGroup, BooleanValue, StringValue
 from django.utils.translation import ugettext as _
 
 SOCIAL_SHARING = ConfigurationGroup(
@@ -54,5 +54,17 @@ settings.register(
         'ENABLE_SHARING_GOOGLE',
         default=True,
         description=_('Check to enable sharing of questions on Google+')
+    )
+)
+
+settings.register(
+    StringValue(
+        SOCIAL_SHARING,
+        'SHARING_SUFFIX_TEXT',
+        default='',
+        description=_('Text (e.g. Hashtag) to add to all social sharing options'),
+        help_text=_(
+                    'Text to add to all social sharing options. Keep it short!'
+                    )
     )
 )

--- a/askbot/skins/common/media/js/post.js
+++ b/askbot/skins/common/media/js/post.js
@@ -1587,7 +1587,7 @@ var socialSharing = function(){
     return {
         init: function(){
             URL = window.location.href;
-            TEXT = escape($('h1 > a').html());
+            TEXT = escape($('h1 > a').attr('title'));
             var fb = $('a.facebook-share')
             var tw = $('a.twitter-share');
             var ln = $('a.linkedin-share');

--- a/askbot/skins/default/templates/question/question_card.html
+++ b/askbot/skins/default/templates/question/question_card.html
@@ -4,7 +4,9 @@
 </div>
 <div class="question-content">
 
-    <h1><a href="{{ question.get_absolute_url() }}">{{ question.get_question_title() }}</a></h1>
+    <h1><a href="{{ question.get_absolute_url() }}"
+        {% if settings.SHARING_SUFFIX_TEXT %}title="{{question.get_question_title()}} {{ settings.SHARING_SUFFIX_TEXT }}{% endif %}"
+    >{{ question.get_question_title() }}</a></h1>
     {% include "question/question_tags.html" %}
     <div id="question-table" {% if question.deleted %}class="deleted"{%endif%}>
         <div class="question-body">


### PR DESCRIPTION
a text that is added to each social media sharing. This way it is
possible to have all twitter/identi.ca postings made from an askbot
instance include something like for example a hashtag pointing
to the instance.

This was requested for ask.fedoraproject.org: http://ask.fedoraproject.org/question/444/rfe-add-askfedora-fedora-tags-to-twitter-identica

What this change does is change the origin of the text that is posted to the social networking sites from h1 > a to h1 > a.attr('title') - and the a.title attribute is filled with the suffix-snippet earlier. I couldn't think of a cleaner way to do this. I you can - please let me know.

Thanks.
