### PR TITLE
made the editor area toggle-able in `ask question` view

### DIFF
--- a/askbot/skins/common/templates/widgets/edit_post.html
+++ b/askbot/skins/common/templates/widgets/edit_post.html
@@ -7,11 +7,45 @@
         </div>
     </div>
 {% endif %}
+
+{% if editor_toggle %}
+    <div class="preview-toggle">
+        <span
+            id="shown-collapse"
+            title="{% trans %}Toggle extended question details{% endtrans %}"
+        >
+        {% if editor_toggle == "off" %}
+            [{% trans %}add question details{% endtrans %}]
+        {% else %}
+            [{% trans %}hide question details{% endtrans %}]
+        {% endif %}
+        </span>
+    </div>
+
+    {% if editor_toggle == "off" %}
+<div id="explain-area" style="display: none">
+    {% else %}
+<div id="explain-area">
+    {% endif %}
+{% endif %}
 <div id="wmd-button-bar" class="wmd-panel"></div>
 <div class="form-item">
     {{ post_form.text }}{# this element is resizable and will be wrapped by js #}
     <label for="editor" class="form-error">{{ post_form.text.errors }}</label>
 </div>
+<div class="preview-toggle">
+    <span
+        id="pre-collapse"
+        title="{% trans %}Toggle the real time Markdown editor preview{% endtrans %}"
+    >
+        [{% trans %}hide preview{% endtrans %}]
+    </span>
+</div>
+<div id="previewer" class="wmd-preview"></div>
+{% if editor_toggle %}
+</div>
+{% endif %}
+
 {# need label element for resizable input, b/c form validation won't find span #}
 {% if post_type == 'question' %}
     <div class="form-item">
@@ -50,12 +84,3 @@
         <div class="form-error" >{{ post_form.summary.errors }}</div>
     </div>
 {% endif %}
-<div class="preview-toggle">
-    <span 
-        id="pre-collapse" 
-        title="{% trans %}Toggle the real time Markdown editor preview{% endtrans %}"
-    >
-        [{% trans %}hide preview{% endtrans %}]
-    </span>
-</div>
-<div id="previewer" class="wmd-preview"></div>

--- a/askbot/skins/default/templates/ask.html
+++ b/askbot/skins/default/templates/ask.html
@@ -10,7 +10,7 @@
 {% include "widgets/question_edit_tips.html" %}
 {% endblock %}
 {% block content %}
-        {% include "widgets/ask_form.html" %}
+    {% include "widgets/ask_form.html" %}
 {% endblock %}
 {% block endjs %}
     <script type='text/javascript' src='{{"/js/editor.js"|media}}'></script>
@@ -42,6 +42,21 @@
             //highlight code synctax when editor has new text
             $("#editor").typeWatch({highlight: false, wait: 3000,
                              captureLength: 5, callback: lanai.highlightSyntax});
+
+            // make the entire "extended question details" area toggle-able
+            {% if editor_toggle %}
+                {% if editor_toggle == 'off' %}
+                    var shown = false;
+                {% else %}
+                    var shown = true;
+                {% endif %}
+                $('#shown-collapse').bind('click', function(){
+                    var shown_txt = shown ? "[{% trans %}add question details{% endtrans %}]" : "[{% trans %}hide question details{% endtrans %}]";
+                    shown = !shown;
+                    $('#explain-area').toggle(shown);
+                    $('#shown-collapse').text(shown_txt);
+                });
+            {% endif %}
 
             //toggle preview of editor
             //todo remove copy-paste

--- a/askbot/skins/default/templates/macros.html
+++ b/askbot/skins/default/templates/macros.html
@@ -433,6 +433,7 @@ for the purposes of the AJAX comment editor #}
                 post_form,
                 post_type = None,
                 mandatory_tags = None,
+                editor_toggle = None,
                 edit_title = False
             )
 -%}

--- a/askbot/skins/default/templates/widgets/ask_form.html
+++ b/askbot/skins/default/templates/widgets/ask_form.html
@@ -27,6 +27,7 @@
             form,
             post_type = 'question',
             edit_title = False,
+            editor_toggle = editor_toggle,
             mandatory_tags = mandatory_tags
         )
     }}

--- a/askbot/views/writers.py
+++ b/askbot/views/writers.py
@@ -284,6 +284,7 @@ def ask(request):#view used to ask a new question
         'form' : form,
         'mandatory_tags': models.tag.get_mandatory_tags(),
         'email_validation_faq_url':reverse('faq') + '#validate',
+        'editor_toggle': 'off', # enable "toggle editor area" switch, and hide the area by default
     }
     return render_into_skin('ask.html', data, request)
 


### PR DESCRIPTION
On our site, questions usually consist only of title. But askbot doesn't allow empty question body (there's a hard-coded limit of 10 chars). We wanted to make the body optional:
1. allowing empty body (questions with title only)
2. making the entire body editing area hidden by default, but with possibility to toggle it on (ala the Markdown preview toggle).

Nr. 1 is in a separate pull request, as I think it's universally useful to be able to set the minimum length via livesettings.

This pull request is about 2. This is _not a bug fix_; it's a feature we implemented for ourselves. I'm opening this pull request just for discussion / in case someone else finds it useful, not necessarily to be merged.

---

**Askbot `ask question` page right now**:

![current](http://radimrehurek.com/no_toggle.png)

---

**Askbot after this patch**:

![off](http://radimrehurek.com/toggle_off.png)

**And after clicking on the toggle link**:

![off](http://radimrehurek.com/toggle_on.png)
