### PR TITLE
fixed compatibility issue with new html5lib release

### DIFF
--- a/askbot/utils/html.py
+++ b/askbot/utils/html.py
@@ -28,10 +28,10 @@ class HTMLSanitizerMixin(sanitizer.HTMLSanitizerMixin):
 
 class HTMLSanitizer(tokenizer.HTMLTokenizer, HTMLSanitizerMixin):
     def __init__(self, stream, encoding=None, parseMeta=True, useChardet=True,
-                 lowercaseElementName=True, lowercaseAttrName=True):
+                 lowercaseElementName=True, lowercaseAttrName=True, **kwargs):
         tokenizer.HTMLTokenizer.__init__(self, stream, encoding, parseMeta,
                                          useChardet, lowercaseElementName,
-                                         lowercaseAttrName)
+                                         lowercaseAttrName, **kwargs)
 
     def __iter__(self):
         for token in tokenizer.HTMLTokenizer.__iter__(self):


### PR DESCRIPTION
New html5lib (v0.95) introduced a new tokenizer parameter, `parser`. Askbot now fails with 

```
/home/www-data/askbot_gobs/askbot/middleware/pagesize.py TIME: 2012-03-07 11:29:31,972 MSG: pagesize.py:process_exception:43   File "/home/www-data/workspace/vew/gobs/lib/python2.6/site-packages/Django
-1.3.1-py2.6.egg/django/core/handlers/base.py", line 111, in get_response
    response = callback(request, *callback_args, **callback_kwargs)
  File "/home/www-data/workspace/vew/gobs/lib/python2.6/site-packages/Django-1.3.1-py2.6.egg/django/utils/decorators.py", line 93, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "/home/www-data/askbot_gobs/askbot/utils/decorators.py", line 122, in wrapper
    return view_func(request, *args, **kwargs)
  File "/home/www-data/askbot_gobs/askbot/utils/decorators.py", line 217, in wrapper
    return view_func(request, *args, **kwargs)
  File "/home/www-data/askbot_gobs/askbot/views/commands.py", line 130, in flashcard_ask
    timestamp=timestamp
  File "/home/www-data/askbot_gobs/askbot/models/__init__.py", line 1339, in user_post_question
    is_anonymous = is_anonymous,
  File "/home/www-data/askbot_gobs/askbot/models/question.py", line 109, in create_new
    question.parse_and_save(author = author)
  File "/home/www-data/askbot_gobs/askbot/models/base.py", line 114, in parse_and_save_post
    data = post.parse()
  File "/home/www-data/askbot_gobs/askbot/models/base.py", line 45, in parse_post_text
    text = sanitize_html(markup.get_parser().convert(text))
  File "/home/www-data/askbot_gobs/askbot/utils/html.py", line 46, in sanitize_html
    dom_tree = p.parseFragment(html)
  File "/home/www-data/workspace/vew/gobs/lib/python2.6/site-packages/html5lib-0.95-py2.6.egg/html5lib/html5parser.py", line 264, in parseFragment
    self._parse(stream, True, container=container, encoding=encoding)
  File "/home/www-data/workspace/vew/gobs/lib/python2.6/site-packages/html5lib-0.95-py2.6.egg/html5lib/html5parser.py", line 110, in _parse
    parser=self, **kwargs)
```

This patch allows accepting additional constructor params in the `HTMLSanitizer` mixin, which keeps the new tokenizer API in html5lib happy.

Another resolution would be to fix html5lib dependency version to e.g. 0.90, which still worked with askbot.
