### PR TITLE
AccountRecoveryForm: Search e-mail case-insensitive

### DIFF
--- a/askbot/deps/django_authopenid/forms.py
+++ b/askbot/deps/django_authopenid/forms.py
@@ -392,7 +392,7 @@ class AccountRecoveryForm(forms.Form):
         if 'email' in self.cleaned_data:
             email = self.cleaned_data['email']
             try:
-                user = User.objects.get(email=email)
+                user = User.objects.get(email__iexact=email)
                 self.cleaned_data['user'] = user
             except User.DoesNotExist:
                 del self.cleaned_data['email']


### PR DESCRIPTION
E-mail addresses are usually treated as case-insensitive, so it makes
sense to be lenient here.
