### PR TITLE
Fix paths in cronjob template file

### DIFF
--- a/askbot/cron/askbot_cron_job
+++ b/askbot/cron/askbot_cron_job
@@ -9,7 +9,7 @@ PROJECT_PARENT_DIR=/path/to/dir_containing_askbot_site
 PROJECT_DIR_NAME=askbot_site
 
 export PYTHONPATH=$PROJECT_PARENT_DIR:$PYTHONPATH
-PROJECT_ROOT=$PYTHONPATH/$PROJECT_NAME
+PROJECT_ROOT=$PROJECT_PARENT_DIR/$PROJECT_DIR_NAME
 
 #these are actual commands that are to be run
 python $PROJECT_ROOT/manage.py send_email_alerts


### PR DESCRIPTION
By the way, why is PYTHONPATH extended with the parent dir there? In my case here that doesn't make any sense as it's `/home/askbot/` and doesn't contain any Python code directly.
