### PR TITLE
correct path to manage.py

### DIFF
--- a/askbot/cron/askbot_cron_job
+++ b/askbot/cron/askbot_cron_job
@@ -9,7 +9,7 @@ PROJECT_PARENT_DIR=/path/to/dir_containing_askbot_site
 PROJECT_DIR_NAME=askbot_site
 
 export PYTHONPATH=$PROJECT_PARENT_DIR:$PYTHONPATH
-PROJECT_ROOT=$PYTHONPATH/$PROJECT_NAME
+PROJECT_ROOT=$PROJECT_DIR_NAME/$PROJECT_NAME
 
 #these are actual commands that are to be run
 python $PROJECT_ROOT/manage.py send_email_alerts


### PR DESCRIPTION
original path used PYTHONPATH as the path prefix, so it would end up with multiple colon separated paths as the first part of the path to manage.py
