### PR TITLE
Fixing some JavaScript

### DIFF
--- a/askbot/skins/default/templates/meta/editor_data.html
+++ b/askbot/skins/default/templates/meta/editor_data.html
@@ -3,11 +3,11 @@
     askbot['settings']['tagsAreRequired'] = 
         {% if settings.TAGS_ARE_REQUIRED %}true{% else %}false{% endif %};
     askbot['settings']['maxTagLength'] = {{settings.MAX_TAG_LENGTH}};
-                            'each tag must be shorter than %(max_chars)d characters',
-    askbot['messages']['maxTagLength'] = '{% trans max_chars = settings.MAX_TAG_LENGTH %}each tag must be shorter that {{max_chars}} character{% pluralize %}each tag must be shorter than {{max_chars}} characters{% endtrans %}';
+                            "each tag must be shorter than %(max_chars)d characters",
+    askbot['messages']['maxTagLength'] = "{% trans max_chars = settings.MAX_TAG_LENGTH %}each tag must be shorter that {{max_chars}} character{% pluralize %}each tag must be shorter than {{max_chars}} characters{% endtrans %}";
     askbot['settings']['maxTagsPerPost'] = {{settings.MAX_TAGS_PER_POST}};
-    askbot['messages']['maxTagsPerPost'] = '{% trans tag_count = settings.MAX_TAGS_PER_POST %}please use {{tag_count}} tag{% pluralize %}please use {{tag_count}} tags or less{% endtrans %}';
-    askbot['messages']['tagLimits'] = '{% trans tag_count=settings.MAX_TAGS_PER_POST, max_chars=settings.MAX_TAG_LENGTH %}please use up to {{tag_count}} tags, less than {{max_chars}} characters each{% endtrans %}'; 
+    askbot['messages']['maxTagsPerPost'] = "{% trans tag_count = settings.MAX_TAGS_PER_POST %}please use {{tag_count}} tag{% pluralize %}please use {{tag_count}} tags or less{% endtrans %}";
+    askbot['messages']['tagLimits'] = "{% trans tag_count=settings.MAX_TAGS_PER_POST, max_chars=settings.MAX_TAG_LENGTH %}please use up to {{tag_count}} tags, less than {{max_chars}} characters each{% endtrans %}";
     askbot['urls']['upload'] = '{% url "upload" %}';
     askbot['settings']['minTitleLength'] = {{settings.MIN_TITLE_LENGTH}}
     askbot['settings']['minQuestionBodyLength'] = {{settings.MIN_QUESTION_BODY_LENGTH}}


### PR DESCRIPTION
If a locale string contains a single quote ', it can collide with the quotes
defining the string at javascript level (it happens for french locale at
least).
