### PR TITLE
Rss feed link changed to use the `url` template tag. 

### DIFF
--- a/askbot/skins/default/templates/main_page/tab_bar.html
+++ b/askbot/skins/default/templates/main_page/tab_bar.html
@@ -2,11 +2,7 @@
 {% load extra_filters_jinja %}
 {% cache 0 "scope_sort_tabs" search_tags request.user author_name scope sort query context.page language_code %}
 <a class="rss"
-    {% if feed_url %}
-    href="{{feed_url}}"
-    {% else %}
-    href="/feeds/rss/"
-    {% endif %}
+    {% url feed 'rss' %}
     title="{% trans %}subscribe to the questions feed{% endtrans %}"
     >{% trans %}RSS{% endtrans %}
 </a>


### PR DESCRIPTION
Hello, this pull request is referenced from this askbot forum message: http://askbot.org/en/question/7950/feedsrss-path-not-appended-to-askboturl/
