### PR TITLE
Use `url` template tag for feeds url

### DIFF
--- a/askbot/skins/default/templates/main_page/tab_bar.html
+++ b/askbot/skins/default/templates/main_page/tab_bar.html
@@ -2,11 +2,7 @@
 {% load extra_filters_jinja %}
 {% cache 0 "scope_sort_tabs" search_tags request.user author_name scope sort query context.page language_code %}
 <a class="rss"
-    {% if feed_url %}
-    href="{{feed_url}}"
-    {% else %}
-    href="/feeds/rss/"
-    {% endif %}
+    href="{% url feeds 'rss' %}"
     title="{% trans %}subscribe to the questions feed{% endtrans %}"
     >{% trans %}RSS{% endtrans %}
 </a>


### PR DESCRIPTION
Fixes a problem where the /feeds/rss url was hardcoded on an askbot installation that was in a subdirectory.
