### PR TITLE
Removes the white brackground from the RSS icon element.

### DIFF
--- a/askbot/media/style/style.css
+++ b/askbot/media/style/style.css
@@ -942,7 +942,7 @@ body.anon #searchBar .searchInputCancelable {
   width: 52px;
   padding-left: 2px;
   padding-top: 3px;
-  background: #ffffff url(../images/feed-icon-small.png) no-repeat center right;
+  background: transparent url(../images/feed-icon-small.png) no-repeat center right;
   float: right;
   font-family: Georgia, serif;
   font-size: 16px;

--- a/askbot/media/style/style.less
+++ b/askbot/media/style/style.less
@@ -886,7 +886,7 @@ body.anon {
     width:52px;
     padding-left: 2px;
     padding-top:3px;
-    background:#fff url(../images/feed-icon-small.png) no-repeat center right;
+    background:transparent url(../images/feed-icon-small.png) no-repeat center right;
     float:right;
     font-family:@sort-font;
     font-size:16px;


### PR DESCRIPTION
The white background works fine with Askbot's default skin, but there's really no reason to keep it there, when it could just be transparent.
