### PR TITLE
Adds overflow:hidden to .box selector.

### DIFF
--- a/askbot/media/style/style.css
+++ b/askbot/media/style/style.css
@@ -580,6 +580,7 @@ body.anon #searchBar .searchInputCancelable {
   background: #fff;
   padding: 4px 0px 10px 0px;
   width: 200px;
+  overflow: hidden;
   /* widgets for question template */
 
   /* notify by email box */

--- a/askbot/media/style/style.less
+++ b/askbot/media/style/style.less
@@ -579,6 +579,7 @@ body.anon {
     background: #fff;
     padding: 4px 0px 10px 0px;
     width:200px;
+    overflow: hidden;
 
     p {
         margin-bottom: 4px;


### PR DESCRIPTION
Without it, the .box would not be as tall as its content. While
that works fine for Askbot's default skin (boxes are white on a
white background), it will fail on skins in which boxes have a border
or a different background color. There's no reason not to fix this
in the default skin.
