### PR TITLE
Adds options to disable Tinyurl and use own short link instead.

### DIFF
--- a/askbot/conf/site_settings.py
+++ b/askbot/conf/site_settings.py
@@ -71,6 +71,20 @@ settings.register(
 )
 
 settings.register(
+    livesettings.StringValue(
+        QA_SITE_SETTINGS,
+        'QUESTION_SHORT_URL',
+        description=_(
+                'Shortened base URL for single questions on your Q&A forum, '
+                'must start with http or https. It will be used if you have '
+                'disabled Tinyurl and it may or may not include the '
+                '/question/ part, according to how you have configured your '
+                'webserver'
+            ),
+    )
+)
+
+settings.register(
     livesettings.BooleanValue(
         QA_SITE_SETTINGS,
         'ENABLE_GREETING_FOR_ANON_USER',

--- a/askbot/conf/social_sharing.py
+++ b/askbot/conf/social_sharing.py
@@ -15,6 +15,15 @@ SOCIAL_SHARING = ConfigurationGroup(
 settings.register(
     BooleanValue(
         SOCIAL_SHARING,
+        'ENABLE_TINYURL',
+        default=True,
+        description=_('Check to enable shortening the URLs with tinyurl')
+    )
+)
+
+settings.register(
+    BooleanValue(
+        SOCIAL_SHARING,
         'ENABLE_SHARING_TWITTER',
         default=True,
         description=_('Check to enable sharing of questions on Twitter')

--- a/askbot/media/js/post.js
+++ b/askbot/media/js/post.js
@@ -2066,25 +2066,49 @@ var socialSharing = function(){
     var share_page = function(service_name){
         if (SERVICE_DATA[service_name]){
             var url = SERVICE_DATA[service_name]['url'];
-            $.ajax({
-                async: false,
-                url: "http://json-tinyurl.appspot.com/?&callback=?",
-                dataType: "json",
-                data: {'url':URL},
-                success: function(data){
-                    url = url.replace('{URL}', data.tinyurl);
-                },
-                error: function(data){
-                    url = url.replace('{URL}', URL);
-                },
-                complete: function(data){
-                    url = url.replace('{TEXT}', TEXT);
-                    var params = SERVICE_DATA[service_name]['params'];
-                    if(!window.open(url, "sharing", params)){
-                        window.location.href=url;
-                    }
+
+            var set_sharing_url = function(u) {
+                url = url.replace('{URL}', u);
+            }
+
+            var set_sharing_text = function(t) {
+                url = url.replace('{TEXT}', t);
+            }
+
+            var open_sharing_window = function() {
+                var params = SERVICE_DATA[service_name]['params'];
+                if(!window.open(url, "sharing", params)){
+                    window.location.href=url;
                 }
-            });
+            }
+
+            if (askbot['settings']['tinyurl_enabled']) {
+                $.ajax({
+                    async: false,
+                    url: "http://json-tinyurl.appspot.com/?&callback=?",
+                    dataType: "json",
+                    data: {'url':URL},
+                    success: function(data){
+                        set_sharing_url(data.tinyurl);
+                    },
+                    error: function(data){
+                        set_sharing_url(URL);
+                    },
+                    complete: function(data){
+                        set_sharing_text(TEXT);
+                        open_sharing_window();
+                    }
+                });
+            } else {
+                if (askbot['settings']['question_short_url']) {
+                    set_sharing_url(askbot['settings']['question_short_url'] + '/' +
+                                    askbot['data']['question_id'] + '/');
+                } else {
+                    set_sharing_url(window.location.href);
+                }
+                set_sharing_text(TEXT);
+                open_sharing_window();
+            }
         }
     }
 

--- a/askbot/templates/meta/editor_data.html
+++ b/askbot/templates/meta/editor_data.html
@@ -13,4 +13,6 @@
     askbot['settings']['minQuestionBodyLength'] = {{settings.MIN_QUESTION_BODY_LENGTH}};
     askbot['settings']['minAnswerBodyLength'] = {{settings.MIN_ANSWER_BODY_LENGTH}};
     askbot['settings']['tag_editor'] = '{{ tag_editor_settings|escapejs }}';
+    askbot['settings']['tinyurl_enabled'] = '{{settings.ENABLE_TINYURL}}' === 'True';
+    askbot['settings']['question_short_url'] = '{{settings.QUESTION_SHORT_URL}}'
 </script>

--- a/askbot/templates/question/javascript.html
+++ b/askbot/templates/question/javascript.html
@@ -1,5 +1,6 @@
 <script type='text/javascript' src='{{"/js/editor.js"|media}}'></script>
 <script type='text/javascript'>
+    askbot['data']['question_id'] = {{question.id}};
     {% if settings.ENABLE_MATHJAX or settings.MARKUP_CODE_FRIENDLY %}
     var codeFriendlyMarkdown = true;
     {% else %}


### PR DESCRIPTION
If Tinyurl is not enabled, AskBot will attempt to use the
QUESTION_SHORT_URL setting. If that's not present, then the
current window.location.href will be used.
