### PR TITLE
Fixed a settings manipulation that was breaking other tests.

### DIFF
--- a/askbot/tests/skin_tests.py
+++ b/askbot/tests/skin_tests.py
@@ -39,7 +39,10 @@ class SkinTests(TestCase):
                         )
         shutil.rmtree(self.temp_dir)
         askbot_settings.update('ASKBOT_DEFAULT_SKIN', 'default')
-        django_settings.ASKBOT_EXTRA_SKINS_DIR = self.skins_dir_backup
+        if self.skins_dir_backup is None:
+            del(django_settings.ASKBOT_EXTRA_SKINS_DIR)
+        else:
+            django_settings.ASKBOT_EXTRA_SKINS_DIR = self.skins_dir_backup
 
     def assert_default_logo_in_skin(self, skin_name):
         url = skin_utils.get_media_url(askbot_settings.SITE_LOGO_URL)


### PR DESCRIPTION
The manipulation of ASKBOT_EXTRA_SKINS was breaking widget_tests and
post_model_tests when running the full askbot test suite.

If the settings attribute ASKBOT_EXTRA_SKINS wasn't set before the test running, it would be initialized with value None on the tearDown. This would break subsequent tests that would test for the existance of ASKBOT_EXTRA_SKINS.
