### PR TITLE
Expose stack traces to error logs

### DIFF
--- a/askbot/startup_procedures.py
+++ b/askbot/startup_procedures.py
@@ -909,12 +909,11 @@ def run():
         run_startup_tests()
     except AskbotConfigError, error:
         transaction.rollback()
-        print error
-        sys.exit(1)
+        raise
     try:
         from askbot.models import badges
         badges.init_badges()
         transaction.commit()
     except Exception, error:
-        print error
         transaction.rollback()
+        raise


### PR DESCRIPTION
I found that this made it much easier to debug a busted askbot upgrade.

Without it, you don't get to see the line numbers of where errors are coming from.

Cheers, and thanks for the great project.
