### PR TITLE
Fix bug causing askbot-setup script to never accept a sqlite filename

### DIFF
--- a/askbot/deployment/__init__.py
+++ b/askbot/deployment/__init__.py
@@ -217,6 +217,8 @@ def collect_missing_options(options_dict):
                 print 'name %s cannot be used for the database name' % value
             elif value == path_utils.LOG_DIR_NAME:
                 print 'name %s cannot be used for the database name' % value
+            else:
+                database_file_name = value
 
             if database_file_name:
                 options_dict['database_name'] = database_file_name


### PR DESCRIPTION
Pretty self-explanatory, I think.
