### PR TITLE
Add a live setting about allowing answering own questions.

### DIFF
--- a/askbot/conf/forum_data_rules.py
+++ b/askbot/conf/forum_data_rules.py
@@ -66,6 +66,19 @@ settings.register(
 settings.register(
     livesettings.BooleanValue(
         FORUM_DATA_RULES,
+        'ALLOW_ANSWER_OWN_QUESTIONS',
+        default=True,
+        description=_('Allow answering own questions'),
+        help_text=_(
+            'Check this if you would like to allow users to '
+            'answer their own questions.'
+        )
+    )
+)
+
+settings.register(
+    livesettings.BooleanValue(
+        FORUM_DATA_RULES,
         'ALLOW_POSTING_BEFORE_LOGGING_IN',
         default = True,
         description = _('Allow posting before logging in'),
@@ -354,7 +367,7 @@ settings.register(
     )
 )
 
-#todo: looks like there is a bug in askbot.deps.livesettings 
+#todo: looks like there is a bug in askbot.deps.livesettings
 #that does not allow Integer values with defaults and choices
 settings.register(
     livesettings.StringValue(

--- a/askbot/exceptions.py
+++ b/askbot/exceptions.py
@@ -24,6 +24,10 @@ class AnswerAlreadyGiven(exceptions.PermissionDenied):
     to the same question"""
     pass
 
+class AnsweringOwnQuestion(exceptions.PermissionDenied):
+    """Raised when user attempts to answer his own question."""
+    pass
+
 class DuplicateCommand(exceptions.PermissionDenied):
     """exception class to indicate that something
     that can happen only once was attempted for the second time

--- a/askbot/models/__init__.py
+++ b/askbot/models/__init__.py
@@ -1901,6 +1901,13 @@ def user_post_answer(
     #todo: move this to assertion - user_assert_can_post_answer
     if self == question.author and not self.is_administrator():
 
+        if not askbot_settings.ALLOW_ANSWER_OWN_QUESTIONS:
+            error_message = _(
+                'Sorry, you cannot answer your own question. Please edit it or '
+                'comment an existing answer instead.'
+            )
+            raise askbot_exceptions.AnsweringOwnQuestion(error_message)
+
         # check date and rep required to post answer to own question
 
         delta = datetime.timedelta(askbot_settings.MIN_DAYS_TO_ANSWER_OWN_QUESTION)

--- a/askbot/templates/question/new_answer_form.html
+++ b/askbot/templates/question/new_answer_form.html
@@ -27,35 +27,42 @@
                     </h2>
                 {% endspaceless %}
             </div>
-            {% if request.user.is_anonymous() %}
-                <div class="message">{% trans %}<span class='strong big'>Please start posting your answer anonymously</span> - your answer will be saved within the current session and published after you log in or create a new account. Please try to give a <strong>substantial answer</strong>, for discussions, <strong>please use comments</strong> and <strong>please do remember to vote</strong> (after you log in)!{% endtrans %}</div>
-            {% else %}
-                <p class="message">
-                    {% if request.user==question.author  %}
-                        {% trans %}<span class='big strong'>You are welcome to answer your own question</span>, but please make sure to give an <strong>answer</strong>. Remember that you can always <strong>revise your original question</strong>. Please <strong>use comments for discussions</strong>  and <strong>please don't forget to vote :)</strong> for the answers that you liked (or perhaps did not like)!{% endtrans %}
-                    {% else %}
-                        {% trans %}<span class='big strong'>Please try to give a substantial answer</span>. If you wanted to comment on the question or answer, just <strong>use the commenting tool</strong>. Please remember that you can always <strong>revise your answers</strong> - no need to answer the same question twice. Also, please <strong>don't forget to vote</strong> - it really helps to select the best questions and answers!{% endtrans %}
-                    {% endif %}
+            {% if request.user == question.author and not settings.ALLOW_ANSWER_OWN_QUESTIONS %}
+                <p class='question-instructions'>
+                    <span class='strong big'>{% trans %}Sorry, you cannot answer your own question.{% endtrans %}</span>
+                    {% trans %}If you want to engage in discussion with other users, please comment their answers. If you want to provide further information, please edit your question.{% endtrans %}
                 </p>
-            {% endif %}
-            {{ macros.edit_post(
-                    answer,
-                    user = request.user,
-                    editor_type = settings.EDITOR_TYPE
-                )
-            }}
-            <input id="add-answer-btn" type="submit" class="submit after-editor" style="float:left"/>
-            <script type="text/javascript">
-                askbot['functions']['renderAddAnswerButton']();
-            </script>
-            {% if settings.WIKI_ON %}
-                {{ macros.checkbox_in_div(answer.wiki) }}
-            {% endif %}
-            {% if settings.GROUPS_ENABLED and 
-                request.user.is_authenticated() and 
-                request.user.can_make_group_private_posts()
-            %}
-                {{ macros.checkbox_in_div(answer.post_privately) }}
+            {% else %}
+                {% if request.user.is_anonymous() %}
+                    <div class="message">{% trans %}<span class='strong big'>Please start posting your answer anonymously</span> - your answer will be saved within the current session and published after you log in or create a new account. Please try to give a <strong>substantial answer</strong>, for discussions, <strong>please use comments</strong> and <strong>please do remember to vote</strong> (after you log in)!{% endtrans %}</div>
+                {% else %}
+                    <p class="message">
+                        {% if request.user==question.author  %}
+                            {% trans %}<span class='big strong'>You are welcome to answer your own question</span>, but please make sure to give an <strong>answer</strong>. Remember that you can always <strong>revise your original question</strong>. Please <strong>use comments for discussions</strong>  and <strong>please don't forget to vote :)</strong> for the answers that you liked (or perhaps did not like)!{% endtrans %}
+                        {% else %}
+                            {% trans %}<span class='big strong'>Please try to give a substantial answer</span>. If you wanted to comment on the question or answer, just <strong>use the commenting tool</strong>. Please remember that you can always <strong>revise your answers</strong> - no need to answer the same question twice. Also, please <strong>don't forget to vote</strong> - it really helps to select the best questions and answers!{% endtrans %}
+                        {% endif %}
+                    </p>
+                {% endif %}
+                {{ macros.edit_post(
+                        answer,
+                        user = request.user,
+                        editor_type = settings.EDITOR_TYPE
+                    )
+                }}
+                <input id="add-answer-btn" type="submit" class="submit after-editor" style="float:left"/>
+                <script type="text/javascript">
+                    askbot['functions']['renderAddAnswerButton']();
+                </script>
+                {% if settings.WIKI_ON %}
+                    {{ macros.checkbox_in_div(answer.wiki) }}
+                {% endif %}
+                {% if settings.GROUPS_ENABLED and
+                    request.user.is_authenticated() and
+                    request.user.can_make_group_private_posts()
+                %}
+                    {{ macros.checkbox_in_div(answer.post_privately) }}
+                {% endif %}
             {% endif %}
         {% endif %}
     {% endif %}


### PR DESCRIPTION
A new live setting, ALLOW_ANSWER_OWN_QUESITONS, is defined. By default it's True, but it set to False, the user won't be able to answer their own questions.

The reason is that in some AskBot installations, the topic of discussion might be such that answering one's own question makes little sense.

In my very own case, I implemented this because the user would treat the AskBot site like a forum, and answer their own quesiton to continue the discussion.

It doesn't help that it says everywhere that that's not the correct way to use AskBot. :-)

git-diff has made a little mess in askbot/templates/question/new_answer_form.html, because the new {% if %} block alters the indentation of the code within, so it's hard to read, but it's truly quite simple instead.
