### PR TITLE
Fix encoding problems when sharing a question with special characters

### DIFF
--- a/askbot/media/js/post.js
+++ b/askbot/media/js/post.js
@@ -2107,7 +2107,7 @@ var socialSharing = function(){
             URL = window.location.href;
             var urlBits = URL.split('/');
             URL = urlBits.slice(0, -2).join('/') + '/';
-            TEXT = escape($('h1 > a').html());
+            TEXT = encodeURIComponent($('h1 > a').html());
             var hashtag = encodeURIComponent(
                                 askbot['settings']['sharingSuffixText']
                             );


### PR DESCRIPTION
Twitter complains with the following error message when sharing a question that contains special characters, such as accented vowels:

```
Invalid Unicode value in one or more parameters
```

The problem is that JS encode() function doesn't handle UTF-8 characters, but encodeURIComponent() actually does.

This PR replaces `escape()` with `encodeURIComponent()` when sharing a question.
