### PR TITLE
Fix. UnicodeDecodeError

### DIFF
--- a/askbot/deps/livesettings/values.py
+++ b/askbot/deps/livesettings/values.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Taken and modified from the dbsettings project.
 
 http://code.google.com/p/django-values/


### PR DESCRIPTION
Askbot raised an error when i was trying to edit forum settings.

> UnicodeDecodeError at /askbot/settings/EMAIL/
> 'ascii' codec can't decode byte 0xd0 in position 0: ordinal not in range(128)
> Request Method:   GET
> Request URL:  askbot/settings/EMAIL/
> Django Version:   1.4.5
> Exception Type:   UnicodeDecodeError
> Exception Value:  
> 'ascii' codec can't decode byte 0xd0 in position 0: ordinal not in range(128)
> Exception Location:   askbot/deps/livesettings/values.py in _default_text, line 252

I patched it a little. 
