### PR TITLE
fix errors caused by user names with unicode data

### DIFF
--- a/askbot/models/question.py
+++ b/askbot/models/question.py
@@ -1449,8 +1449,12 @@ class FavoriteQuestion(models.Model):
     class Meta:
         app_label = 'askbot'
         db_table = u'favorite_question'
+
+    def __str__(self):
+        return unicode(self).encode('utf-8')
+
     def __unicode__(self):
-        return '[%s] favorited at %s' %(self.user, self.added_at)
+        return u'[%s] favorited at %s' %(self.user, self.added_at)
 
 
 class DraftQuestion(models.Model):

--- a/askbot/models/user.py
+++ b/askbot/models/user.py
@@ -311,13 +311,15 @@ class EmailFeedSetting(models.Model):
         unique_together = ('subscriber', 'feed_type')
         app_label = 'askbot'
 
-
     def __str__(self):
+        return unicode(self).encode('utf-8')
+
+    def __unicode__(self):
         if self.reported_at is None:
             reported_at = "'not yet'"
         else:
             reported_at = '%s' % self.reported_at.strftime('%d/%m/%y %H:%M')
-        return 'Email feed for %s type=%s, frequency=%s, reported_at=%s' % (
+        return u'Email feed for %s type=%s, frequency=%s, reported_at=%s' % (
                                                      self.subscriber,
                                                      self.feed_type,
                                                      self.frequency,


### PR DESCRIPTION
In doing work to get the zendesk import working, I encountered errors in the django admin related to our users having unicode characters in their names. This implementation is consistent with the best practice for python 2.x as described here http://stackoverflow.com/questions/1307014/python-str-versus-unicode
