### PR TITLE
fix bug where private key was hard-coded as 2.

### DIFF
--- a/askbot/tests/management_command_tests.py
+++ b/askbot/tests/management_command_tests.py
@@ -34,20 +34,19 @@ class ManagementCommandTests(AskbotTestCase):
         question = self.post_question(user=user_one)
         comment = self.post_comment(user=user_one, parent_post=question)
         number_of_gold = 50
-        user_one.gold = number_of_gold 
+        user_one.gold = number_of_gold
         reputation = 20
-        user_one.reputation = reputation 
+        user_one.reputation = reputation
         user_one.save()
         # Create a second user and transfer all objects from 'user_one' to 'user_two'
         user_two = self.create_user(username='unique')
+        user_two_pk = user_two.pk
         management.call_command('merge_users', user_one.id, user_two.id)
         # Check that the first user was deleted
         self.assertEqual(models.User.objects.filter(pk=user_one.id).count(), 0)
         # Explicitly check that the values assigned to user_one are now user_two's
         self.assertEqual(user_two.posts.get_questions().filter(pk=question.id).count(), 1)
         self.assertEqual(user_two.posts.get_comments().filter(pk=comment.id).count(), 1)
-        #todo: change groups to django groups
-        #then replace to 3 back to 2 in the line below
-        user_two = models.User.objects.get(pk=2)
-        self.assertEqual(user_two.gold, number_of_gold) 
+        user_two = models.User.objects.get(pk=user_two_pk)
+        self.assertEqual(user_two.gold, number_of_gold)
         self.assertEqual(user_two.reputation, reputation)


### PR DESCRIPTION
Previously this test failed in MySQL because the private key
for user_two was hard-coded as 2. This change determines it
programatically from user_two, which lets the MySQL test work
properly.
