### PR TITLE
tweak slugify code to avoid double-unidecode

### DIFF
--- a/askbot/utils/slug.py
+++ b/askbot/utils/slug.py
@@ -50,10 +50,13 @@ def slugify(input_text, max_length=150):
         return input_text
 
     allow_unicode_slugs = getattr(settings, 'ALLOW_UNICODE_SLUGS', False)
-    if allow_unicode_slugs:
+    if isinstance(input_text, unicode) and not allow_unicode_slugs:
+        input_text = unidecode(input_text)
+
+    if isinstance(input_text, unicode):
         slug = unicode_slugify(input_text)
     else:
-        slug = defaultfilters.slugify(unidecode(input_text))
+        slug = defaultfilters.slugify(input_text)
     while len(slug) > max_length:
         # try to shorten word by word until len(slug) <= max_length
         temp = slug[:slug.rfind('-')]


### PR DESCRIPTION
Previously, slugify would run a unidecode() on the input_text if
unicode slugs were disallowed. This caused a warning if the input_text
was already de-unicode. This splits the logic into two steps: first
demote input_text if unicode is disallowed; then, choose the appropriate
slugify function based on the result.
