### PR TITLE
make email clean test quieter

### DIFF
--- a/askbot/tests/email_parsing_tests.py
+++ b/askbot/tests/email_parsing_tests.py
@@ -18,12 +18,7 @@ class EmailParsingTests(utils.AskbotTestCase):
 
     def test_clean_email_body(self):
         cleaned_body = mail.clean_html_email(self.rendered_template)
-        print "EXPECTED BODY"
-        print self.expected_output
-        print '=================================================='
-        print cleaned_body
-        print "CLEANED BODY"
-        self.assertEqual(cleaned_body, self.expected_output)
+        self.assertEqual(self.expected_output, cleaned_body)
 
     def test_gmail_rich_text_response_stripped(self):
         text = u'\n\nthis is my reply!\n\nOn Wed, Oct 31, 2012 at 1:45 AM, <kp@kp-dev.askbot.com> wrote:\n\n> **\n>            '


### PR DESCRIPTION
Email clean test was printing two strings from the test, even if they
match, which was unnecessary. Fixed so it only prints if they are
different; the default behavior for assertEqual().
