### PR TITLE
Remove manual transactions when deleting tags.

### DIFF
--- a/askbot/management/commands/delete_unused_tags.py
+++ b/askbot/management/commands/delete_unused_tags.py
@@ -6,7 +6,6 @@ from askbot.conf import settings as askbot_settings
 import sys
 
 class Command(NoArgsCommand):
-    @transaction.commit_manually
     def handle_noargs(self, **options):
         tags = models.Tag.objects.all()
         message = 'Searching for unused tags:'
@@ -17,7 +16,6 @@ class Command(NoArgsCommand):
             if not tag.threads.exists():
                 deleted_tags.append(tag.name)
                 tag.delete()
-            transaction.commit()
 
         if deleted_tags:
             found_count = len(deleted_tags)

--- a/askbot/tests/management_command_tests.py
+++ b/askbot/tests/management_command_tests.py
@@ -128,3 +128,21 @@ class ManagementCommandTests(AskbotTestCase):
 
         print 'done create_tag_synonym_test'
         
+    def test_delete_unused_tags(self):
+
+        user = self.create_user()
+        question = self.post_question(user=user)
+
+        tag_count = models.Tag.objects.count()
+
+        #create some unused tags
+        self.create_tag("picasso", user)
+        self.create_tag("renoir", user)
+        self.create_tag("pissarro", user)
+
+        #check they're in the db
+        self.assertEqual(models.Tag.objects.count(), tag_count+3)
+        management.call_command('delete_unused_tags')
+
+        #now they should be removed
+        self.assertEqual(models.Tag.objects.count(), tag_count)


### PR DESCRIPTION
Handling the transactions manually creates the possiblity
of unclosed transactions as reported here:
http://askbot.org/en/question/11230/errors-while-trying-to-rename-or-delete-unused-tags/

However, there's no need to do this manual handling; the simplest
solution is to just remove the decorator.

Also added tests.
