### PR TITLE
Fix translation injection in inline question javascript

### DIFF
--- a/askbot/templates/question.html
+++ b/askbot/templates/question.html
@@ -185,7 +185,7 @@
                 var deleteBtn = document.getElementById('post-' + post_id + '-delete');
                 var controls = deleteBtn.parentNode;
                 if (//maybe remove "delete" button
-                    (data['userReputation'] < 
+                    (data['userReputation'] <
                     {{settings.MIN_REP_TO_DELETE_OTHERS_COMMENTS}}) ||
                     data['userIsReadOnly']
                 ) {
@@ -244,18 +244,18 @@
                         add_answer_btn.className += ' answer-own-question';
                         add_answer_btn.setAttribute(
                             'value',
-                            '{% trans %}Answer Your Own Question{% endtrans %}'
+                            "{% trans %}Answer Your Own Question{% endtrans %}"
                         )
                     } else {
                         add_answer_btn.setAttribute(
                            'value',
-                            '{% trans %}Post Your Answer{% endtrans %}'
+                            "{% trans %}Post Your Answer{% endtrans %}"
                         )
                     }
                 } else {
                     add_answer_btn.setAttribute(
                         'value',
-                        '{% trans %}Login/Signup to Post{% endtrans %}'
+                        "{% trans %}Login/Signup to Post{% endtrans %}"
                     );
                 }
             }
@@ -277,7 +277,7 @@
                     }
                 }
             }
-            
+
             askbot['functions'] = askbot['functions'] || {};
             askbot['functions']['renderPostVoteButtons'] = render_vote_buttons;
             askbot['functions']['renderPostControls'] = render_post_controls;


### PR DESCRIPTION
Changed some simple quotes by double quotes to avoid string breakage in some local using apostrophe (like french).
There may be some other places where the same breakage happen.

By the way, why not using the [built-in Django translation mecanism for javascript](https://docs.djangoproject.com/en/dev/topics/i18n/translation/#internationalization-in-javascript-code) to avoid those kind of breakage ?

My advice: externalize all javascript in js files, use the django/coffin built-in JS translation mecanism and use html attribute to fetch varaiable from js (and allowing to remove all inline JS and to properly compress it).

I can help if needed. I published an app to help: [Django.js](https://github.com/noirbizarre/django.js).
I can provide Jinja/Coffin support if needed.
