### PR TITLE
fixed bug with feedback function and __proxy__ datatype when using gettext_lazy

### DIFF
--- a/askbot/middleware/cancel.py
+++ b/askbot/middleware/cancel.py
@@ -8,7 +8,7 @@ class CancelActionMiddleware(object):
                 msg = getattr(view_func,'CANCEL_MESSAGE')
             except AttributeError:
                 msg = 'action canceled'
-            request.user.message_set.create(message=msg)
+            request.user.message_set.create(message=unicode(msg))
             return HttpResponseRedirect(get_next_url(request))
         else:
             return None


### PR DESCRIPTION
Fixes: http://askbot.org/en/question/11590/feedback-causing-error-500/
