### PR TITLE
enforce csrf protection on edit_comment to prevent a 403 error code issued when trying to edit a comment

### DIFF
--- a/askbot/views/writers.py
+++ b/askbot/views/writers.py
@@ -735,7 +735,7 @@ def post_comments(request):#generic ajax handler to load comments to an object
 
     return response
 
-#@csrf.csrf_exempt
+@csrf.csrf_exempt
 @decorators.ajax_only
 #@decorators.check_spam('comment')
 def edit_comment(request):


### PR DESCRIPTION
Using Django 1.5, and csrf protection enabled, editing a comment was failing because the csrf protection decorator was commented.
