### PR TITLE
Fixes `UndefinedError: 'settings' is undefined` problem.

### DIFF
--- a/askbot/setup_templates/urls.py
+++ b/askbot/setup_templates/urls.py
@@ -2,13 +2,13 @@
 main url configuration file for the askbot site
 """
 from django.conf import settings
-from django.conf.urls.defaults import handler404
-from django.conf.urls.defaults import handler500
 from django.conf.urls.defaults import include
 from django.conf.urls.defaults import patterns
 from django.conf.urls.defaults import url
 from django.conf import settings
 from django.contrib import admin
+
+handler500 = 'askbot.views.meta.server_error'
 
 admin.autodiscover()
 

--- a/askbot/urls.py
+++ b/askbot/urls.py
@@ -5,7 +5,6 @@ import os.path
 import django
 from django.conf import settings
 from django.conf.urls.defaults import url, patterns, include
-from django.conf.urls.defaults import handler500, handler404
 from django.contrib import admin
 from askbot import views
 from askbot.feed import RssLastestQuestionsFeed, RssIndividualQuestionFeed

--- a/askbot/views/meta.py
+++ b/askbot/views/meta.py
@@ -52,11 +52,10 @@ def about(request, template='about.html'):
     }
     return render(request, 'static_page.html', data)
 
-def page_not_found(request, template='404.html'):
-    return generic_view(request, template)
-
 def server_error(request, template='500.html'):
-    return generic_view(request, template)
+    data = dict(settings=askbot_settings, skin=skins.loaders.get_skin())
+    return render_to_response(template,
+                              context_instance=RequestContext(request, data))
 
 def help(request):
     data = {


### PR DESCRIPTION
**Problem**: `500.html` template extends the `base.html` and it requires `settings.APP_TITLE` value. `handler500` wasn't overridden with the `askbot.views.meta.server_error` and the `server_error` method didn't pass the settings to the template.

**Solution**: I modified the `urls.py` template to override the `handler500` value and extended the `server_error` method.

I also removed some unnecessary imports and `askbot.view.meta.page_not_found` (it is unused).

Related Pull Request is [164 - Fixed handler500 and handler404 in the project template, removed unused](https://github.com/ASKBOT/askbot-devel/pull/164) by @fitoria.

**Related questions**:
- [UndefinedError: 'settings' is undefined](http://askbot.org/en/question/9637/undefinederror-settings-is-undefined/)
- [settings is undefined](http://askbot.org/en/question/10427/settings-is-undefined/)
