### PR TITLE
Oauth2: Facebook: Fix email not found

### DIFF
--- a/askbot/deps/django_authopenid/util.py
+++ b/askbot/deps/django_authopenid/util.py
@@ -403,7 +403,8 @@ def get_enabled_major_login_providers():
             'resource_endpoint': 'https://graph.facebook.com/',
             'icon_media_path': '/jquery-openid/images/facebook.gif',
             'get_user_id_function': get_facebook_user_id,
-            'response_parser': lambda data: dict(urlparse.parse_qsl(data))
+            'response_parser': lambda data: dict(urlparse.parse_qsl(data)),
+            'scope': ['email',],
 
         }
     if askbot_settings.TWITTER_KEY and askbot_settings.TWITTER_SECRET:
@@ -825,7 +826,7 @@ def get_oauth2_starter_url(provider_name, csrf_token):
         client_id=client_id,
         redirect_uri=redirect_uri
     )
-    return client.auth_uri(state=csrf_token)
+    return client.auth_uri(state=csrf_token, scope=params['scope'])
 
 
 def ldap_check_password(username, password):


### PR DESCRIPTION
This is the missing added for last commit.
