### PR TITLE
Fix errors when running migrations against MySQL 5.1.72

### DIFF
--- a/askbot/migrations/0055_auto__chg_field_question_thread.py
+++ b/askbot/migrations/0055_auto__chg_field_question_thread.py
@@ -9,7 +9,7 @@ class Migration(SchemaMigration):
     def forwards(self, orm):
         
         # Changing field 'Question.thread'
-        db.alter_column(u'question', 'thread_id', self.gf('django.db.models.fields.related.ForeignKey')(default=0, unique=True, to=orm['askbot.Thread']))
+        db.alter_column(u'question', 'thread_id', self.gf('django.db.models.fields.related.ForeignKey')(default=None, unique=True, to=orm['askbot.Thread']))
 
 
     def backwards(self, orm):

--- a/askbot/migrations/0080_transplant_favquestions_2.py
+++ b/askbot/migrations/0080_transplant_favquestions_2.py
@@ -12,7 +12,7 @@ class Migration(SchemaMigration):
         db.delete_column(u'favorite_question', 'question_id')
 
         # Changing field 'FavoriteQuestion.thread'
-        db.alter_column(u'favorite_question', 'thread_id', self.gf('django.db.models.fields.related.ForeignKey')(default=0, to=orm['askbot.Thread']))
+        db.alter_column(u'favorite_question', 'thread_id', self.gf('django.db.models.fields.related.ForeignKey')(default=None, to=orm['askbot.Thread']))
 
 
     def backwards(self, orm):

--- a/askbot/migrations/0093_auto__del_field_vote_content_type__del_field_vote_object_id__chg_field.py
+++ b/askbot/migrations/0093_auto__del_field_vote_content_type__del_field_vote_object_id__chg_field.py
@@ -18,7 +18,7 @@ class Migration(SchemaMigration):
         db.delete_column(u'vote', 'object_id')
 
         # Changing field 'Vote.voted_post'
-        db.alter_column(u'vote', 'voted_post_id', self.gf('django.db.models.fields.related.ForeignKey')(default=0, to=orm['askbot.Post']))
+        db.alter_column(u'vote', 'voted_post_id', self.gf('django.db.models.fields.related.ForeignKey')(default=None, to=orm['askbot.Post']))
 
         # Adding unique constraint on 'Vote', fields ['user', 'voted_post']
         db.create_unique(u'vote', ['user_id', 'voted_post_id'])

--- a/askbot/migrations/0099_auto__del_field_thread_accepted_answer__del_field_anonymousanswer_ques.py
+++ b/askbot/migrations/0099_auto__del_field_thread_accepted_answer__del_field_anonymousanswer_ques.py
@@ -21,13 +21,13 @@ class Migration(SchemaMigration):
         db.delete_column('askbot_anonymousanswer', 'question_id')
 
         # Changing field 'AnonymousAnswer.question_post'
-        db.alter_column('askbot_anonymousanswer', 'question_post_id', self.gf('django.db.models.fields.related.ForeignKey')(default=0, to=orm['askbot.Post']))
+        db.alter_column('askbot_anonymousanswer', 'question_post_id', self.gf('django.db.models.fields.related.ForeignKey')(default=None, to=orm['askbot.Post']))
 
         # Deleting field 'QuestionView.question'
         db.delete_column('askbot_questionview', 'question_id')
 
         # Changing field 'QuestionView.question_post'
-        db.alter_column('askbot_questionview', 'question_post_id', self.gf('django.db.models.fields.related.ForeignKey')(default=0, to=orm['askbot.Post']))
+        db.alter_column('askbot_questionview', 'question_post_id', self.gf('django.db.models.fields.related.ForeignKey')(default=None, to=orm['askbot.Post']))
 
         # Deleting field 'PostRevision.question'
         db.delete_column('askbot_postrevision', 'question_id')


### PR DESCRIPTION
Fixes the following type of error:
Error in migration: askbot:0055_auto__chg_field_question_thread
ValueError: The database backend does not accept 0 as a value for AutoField.
