### PR TITLE
Allow Django 1.5.x, not just 1.5 itself

### DIFF
--- a/askbot/__init__.py
+++ b/askbot/__init__.py
@@ -13,7 +13,7 @@ VERSION = (0, 7, 49)
 #values - the package qualifier to use for pip
 REQUIREMENTS = {
     'akismet': 'akismet',
-    'django': 'django>=1.3.1,<=1.5',
+    'django': 'django>=1.3.1,<1.6',
     'compressor': 'django-compressor==1.2',
     'jinja2': 'Jinja2',
     'coffin': 'Coffin>=0.3',


### PR DESCRIPTION
setup.py says that "Django 1.3.1 - 1.5.1" are supported but REQUIREMENTS in **init**.py only allows up to 1.5.
