### PR TITLE
make avatar URL configurable

### DIFF
--- a/askbot/conf/site_settings.py
+++ b/askbot/conf/site_settings.py
@@ -97,6 +97,18 @@ settings.register(
 )
 
 settings.register(
+    livesettings.StringValue(
+        QA_SITE_SETTINGS,
+        'AVATAR_URL',
+        description=_(
+                'Base URL for the used avatar service'
+            ),
+        default='http://www.gravatar.com/avatar'
+    )
+)
+
+
+settings.register(
     livesettings.BooleanValue(
         QA_SITE_SETTINGS,
         'ENABLE_GREETING_FOR_ANON_USER',

--- a/askbot/models/__init__.py
+++ b/askbot/models/__init__.py
@@ -265,13 +265,14 @@ User.add_to_class(
     )
 )
 
-GRAVATAR_TEMPLATE = "//www.gravatar.com/avatar/%(gravatar)s?" + \
+GRAVATAR_TEMPLATE = "%(gravatar_url)s/%(gravatar)s?" + \
     "s=%(size)d&amp;d=%(type)s&amp;r=PG"
 
 def user_get_gravatar_url(self, size):
     """returns gravatar url
     """
     return GRAVATAR_TEMPLATE % {
+                'gravatar_url': askbot_settings.AVATAR_URL,
                 'gravatar': self.gravatar,
                 'type': askbot_settings.GRAVATAR_TYPE,
                 'size': size,
@@ -355,7 +356,7 @@ def user_strip_email_signature(self, text):
     return text
 
 def _check_gravatar(gravatar):
-    gravatar_url = "http://www.gravatar.com/avatar/%s?d=404" % gravatar
+    gravatar_url = askbot_settings.AVATAR_URL+"/%s?d=404" % gravatar
     code = urllib.urlopen(gravatar_url).getcode()
     if urllib.urlopen(gravatar_url).getcode() != 404:
         return 'g' #gravatar

--- a/askbot/templatetags/extra_tags.py
+++ b/askbot/templatetags/extra_tags.py
@@ -15,7 +15,7 @@ GRAVATAR_TEMPLATE = (
                      '<a style="text-decoration:none" '
                      'href="%(user_profile_url)s"><img class="gravatar" '
                      'width="%(size)s" height="%(size)s" '
-                     'src="//www.gravatar.com/avatar/%(gravatar_hash)s'
+                     'src="%(gravatar_url)s/%(gravatar_hash)s'
                      '?s=%(size)s&amp;d=%(gravatar_type)s&amp;r=PG" '
                      'title="%(username)s" '
                      'alt="%(alt_text)s" /></a>')
@@ -37,6 +37,7 @@ def gravatar(user, size):
                     )
     #safe_username = template.defaultfilters.urlencode(username)
     return mark_safe(GRAVATAR_TEMPLATE % {
+        'gravatar_url': askbot_settings.AVATAR_URL,
         'user_profile_url': user_profile_url,
         'size': size,
         'gravatar_hash': functions.get_from_dict_or_object(user, 'gravatar'),


### PR DESCRIPTION
Just tested with our local Confluence. Seems to works fine.

No changes in behavior should arise with the default value.
