### PR TITLE
Fix prefork mode

### DIFF
--- a/askbot/startup_procedures.py
+++ b/askbot/startup_procedures.py
@@ -1062,5 +1062,7 @@ def run():
     except AskbotConfigError, error:
         print error
         sys.exit(1)
-    # close DB connection to prevent issues in prefork mode
+    # close DB and cache connections to prevent issues in prefork mode
     connection.close()
+    if hasattr(cache, 'close'):
+        cache.close()


### PR DESCRIPTION
Connections to to DB and cache need to be closed at the end of the startup procedures, because those are not fork safe and cause problems when running Askbot in prefork mode
