### PR TITLE
Fix double escaped html 

### DIFF
--- a/askbot/patches/__init__.py
+++ b/askbot/patches/__init__.py
@@ -20,6 +20,14 @@ def patch_django():
     if major == 1 and minor <=2:
         django_patches.add_render_shortcut()
 
+    if major == 1 and minor > 4:
+        # This shouldn't be required with django < 1.4.x
+        # And not after kee_lazy lands in django.utils.functional
+        try:
+            from django.utils.functional import keep_lazy
+        except ImportError:
+            django_patches.fix_lazy_double_escape()
+
 def patch_coffin():
     """coffin before version 0.3.4
     does not have csrf_token template tag.


### PR DESCRIPTION
Lazy strings get double escaped with django 1.5 https://code.djangoproject.com/ticket/20221
This is visible anywhere where the translated string contain characters, like '&', which are escaped in HTML.
For example the "community wiki (karma is not awarded & many others can edit wiki post)" and "minor edit (don't send alerts)" checkbox labels on question form.
