### PR TITLE
Fix 500 template processing error

### DIFF
--- a/askbot/setup_templates/urls.py
+++ b/askbot/setup_templates/urls.py
@@ -3,7 +3,6 @@ main url configuration file for the askbot site
 """
 from django.conf import settings
 from django.conf.urls.defaults import handler404
-from django.conf.urls.defaults import handler500
 from django.conf.urls.defaults import include
 from django.conf.urls.defaults import patterns
 from django.conf.urls.defaults import url
@@ -40,3 +39,5 @@ if 'rosetta' in settings.INSTALLED_APPS:
     urlpatterns += patterns('',
                     url(r'^rosetta/', include('rosetta.urls')),
                 )
+
+handler500 = 'askbot.views.error.internal_error'

--- a/askbot/urls.py
+++ b/askbot/urls.py
@@ -5,7 +5,6 @@ import os.path
 import django
 from django.conf import settings
 from django.conf.urls.defaults import url, patterns, include
-from django.conf.urls.defaults import handler500, handler404
 from django.contrib import admin
 from askbot import views
 from askbot.feed import RssLastestQuestionsFeed, RssIndividualQuestionFeed

--- a/askbot/views/error.py
+++ b/askbot/views/error.py
@@ -1,0 +1,10 @@
+from django.shortcuts import render
+
+def internal_error(request):
+    data = {}
+    try:
+        from askbot.conf import settings as askbot_settings
+        data['settings'] = askbot_settings
+    except Exception:
+        data['settings'] = {}
+    return render(request, '500.html', data)


### PR DESCRIPTION
The 500.html template inherits base.html, which fails to process if the settings are not in the context.
This patch fixes it for most internal error cases, but it might be better to consider writing a simpler 500 template which does not require anything extra.
