### PR TITLE
Fix for HTML entities in twitter share

### DIFF
--- a/askbot/media/js/post.js
+++ b/askbot/media/js/post.js
@@ -2506,7 +2506,7 @@ var socialSharing = function(){
             URL = window.location.href;
             var urlBits = URL.split('/');
             URL = urlBits.slice(0, -2).join('/') + '/';
-            TEXT = encodeURIComponent($('h1 > a').html());
+            TEXT = encodeURIComponent($('h1 > a').text());
             var hashtag = encodeURIComponent(
                                 askbot['settings']['sharingSuffixText']
                             );


### PR DESCRIPTION
Using the html content of the title passes the html entities like '&amp;' to twitter share, so using text instead
