### PR TITLE
Upgrade django_countries to get more up-to-date countries list (incl South Sudan)

### DIFF
--- a/askbot/__init__.py
+++ b/askbot/__init__.py
@@ -26,7 +26,7 @@ REQUIREMENTS = {
     'robots': 'django-robots',
     'sanction': 'sanction==0.3.1',
     'unidecode': 'unidecode',
-    'django_countries': 'django-countries==1.0.5',
+    'django_countries': 'django-countries==2.1.2',
     'djcelery': 'django-celery==3.0.11',
     'djkombu': 'django-kombu==0.9.4',
     'followit': 'django-followit',

--- a/askbot/forms.py
+++ b/askbot/forms.py
@@ -15,7 +15,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ungettext_lazy, string_concat
 from django.utils.text import get_text_list
 from django.contrib.auth.models import User
-from django_countries import countries
+from django_countries import countries 
 from askbot.utils.forms import NextUrlField, UserNameField
 from askbot.mail import extract_first_email_address
 from recaptcha_works.fields import RecaptchaField
@@ -153,7 +153,7 @@ def tag_strings_match(tag_string, mandatory_tag):
 
 
 
-COUNTRY_CHOICES = (('unknown', _('select country')),) + countries.COUNTRIES
+COUNTRY_CHOICES = (('unknown', _('select country')),) + tuple(countries)
 
 
 class CountryField(forms.ChoiceField):

--- a/askbot/templatetags/extra_filters_jinja.py
+++ b/askbot/templatetags/extra_filters_jinja.py
@@ -24,7 +24,7 @@ from askbot.utils.slug import slugify
 from askbot.shims.django_shims import ResolverMatch
 
 from django_countries import countries
-from django_countries import settings as countries_settings
+from django_countries.conf import settings as countries_settings
 
 register = coffin_template.Library()
 
@@ -118,12 +118,12 @@ def transurl(url):
 
 @register.filter
 def country_display_name(country_code):
-    country_dict = dict(countries.COUNTRIES)
+    country_dict = dict(countries)
     return country_dict[country_code]
 
 @register.filter
 def country_flag_url(country_code):
-    return countries_settings.FLAG_URL % country_code
+    return countries_settings.COUNTRIES_FLAG_URL.format(**country_code)
 
 @register.filter
 def collapse(input):


### PR DESCRIPTION
Upgraded django_countries from 1.0.5 to 2.1.2 so that we get a more up-to-date list of countries. However, the coding interface has changed slightly - I've fixed the askbot code accordingly, but was unable to test the bits that aren't used in KnowledgePoint project:
- templatetags/extra_filters_jinja.py's country_display_name() (should be OK)
- templatetags/extra_filters_jinja.py's country_flag_url() (you'll probably need to provide configuration for this to get the exact correct URL back (see Customize the flag URL section at https://pypi.python.org/pypi/django-countries/2.1.2)
