### PR TITLE
Self-closed font link tags

### DIFF
--- a/askbot/templates/meta/fonts.html
+++ b/askbot/templates/meta/fonts.html
@@ -10,6 +10,6 @@
     </style>
 {% else %}
     {# note: for IE8 we ask for fonts separately #}
-    <link href='//fonts.googleapis.com/css?family=Open+Sans+Condensed:700&amp;subset=latin-ext' rel='stylesheet' type='text/css'>
-    <link href='//fonts.googleapis.com/css?family=Open+Sans+Condensed:700&amp;subset=cyrillic-ext' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Open+Sans+Condensed:700&amp;subset=latin-ext' rel='stylesheet' type='text/css' />
+    <link href='//fonts.googleapis.com/css?family=Open+Sans+Condensed:700&amp;subset=cyrillic-ext' rel='stylesheet' type='text/css' />
 {% endif %}


### PR DESCRIPTION
This is to fix 'end tag for "link" omitted' markup validation error
