### PR TITLE
Use a different subject for new user email validation.

### DIFF
--- a/askbot/deps/django_authopenid/views.py
+++ b/askbot/deps/django_authopenid/views.py
@@ -568,7 +568,7 @@ def signin(request, template_name='authopenid/signin.html'):
                         user_identifier = email,
                         redirect_url = next_url
                     )
-                    
+
             elif login_form.cleaned_data['login_type'] == 'openid':
                 #initiate communication process
                 logging.debug('processing signin with openid submission')
@@ -1236,7 +1236,8 @@ def signup_with_password(request):
                                         'email': email, 'password': password}
                 email_verifier.save()
                 send_email_key(email, email_verifier.key,
-                               handler_url_name='verify_email_and_register')
+                               handler_url_name='verify_email_and_register',
+                               subject=_('Activate your account'))
                 redirect_url = reverse('verify_email_and_register') + \
                                 '?next=' + get_next_url(request)
                 return HttpResponseRedirect(redirect_url)
@@ -1314,13 +1315,12 @@ def set_new_email(user, new_email):
         user.email_isvalid = False
         user.save()
 
-def send_email_key(email, key, handler_url_name='user_account_recover'):
+def send_email_key(email, key, handler_url_name='user_account_recover',
+        subject = _("Recover your %(site)s account") %
+        {'site': askbot_settings.APP_SHORT_NAME}):
     """private function. sends email containing validation key
     to user's email address
     """
-    subject = _("Recover your %(site)s account") % \
-                {'site': askbot_settings.APP_SHORT_NAME}
-
     data = {
         'site_name': askbot_settings.APP_SHORT_NAME,
         'validation_link': site_url(reverse(handler_url_name)) + \


### PR DESCRIPTION
Right now new user email validation shares the same subject with password recovery.
