### PR TITLE
Do not return None if cache does not respond

### DIFF
--- a/askbot/conf/settings_wrapper.py
+++ b/askbot/conf/settings_wrapper.py
@@ -115,8 +115,7 @@ class ConfigSettings(object):
         if settings:
             return settings
         else:
-            self.prime_cache(cache_key)
-            return cache.get(cache_key)
+            return self.prime_cache(cache_key)
 
     @classmethod
     def prime_cache(cls, cache_key, **kwargs):
@@ -131,6 +130,7 @@ class ConfigSettings(object):
             else:
                 out[key] = hardcoded_setting
         cache.set(cache_key, out)
+        return out
 
 
 def get_bulk_cache_key():


### PR DESCRIPTION
If there is cache connection failures, cache.get() will return None even if the same cache value was just set. And also it's more efficient to return the just generated dict instead of taking the round trip through cache.