### PR TITLE
Make sure __unicode__ methods return unicode

### DIFF
--- a/askbot/deps/django_authopenid/models.py
+++ b/askbot/deps/django_authopenid/models.py
@@ -58,7 +58,7 @@ class UserAssociation(models.Model):
                             )
 
     def __unicode__(self):
-        return "Openid %s with user %s" % (self.openid_url, self.user)
+        return u"Openid %s with user %s" % (self.openid_url, self.user)
 
 class UserPasswordQueueManager(models.Manager):
     """ manager for UserPasswordQueue object """

--- a/askbot/models/repute.py
+++ b/askbot/models/repute.py
@@ -50,7 +50,7 @@ class Vote(models.Model):
         db_table = u'vote'
 
     def __unicode__(self):
-        return '[%s] voted at %s: %s' %(self.user, self.voted_at, self.vote)
+        return u'[%s] voted at %s: %s' %(self.user, self.voted_at, self.vote)
 
     def __int__(self):
         """1 if upvote -1 if downvote"""

--- a/askbot/models/widgets.py
+++ b/askbot/models/widgets.py
@@ -18,7 +18,7 @@ class AskWidget(models.Model):
         app_label = 'askbot'
 
     def __unicode__(self):
-        return "Widget: %s" % self.title
+        return u"Widget: %s" % self.title
 
 
 class QuestionWidget(models.Model):


### PR DESCRIPTION
For example Votes admin interface threw UnicodeDecodeError when there was users with non ascii characters in the username. This fixes all **unicode** methods to return unicode objects.
