### PR TITLE
Remember next_url on Oauth signin

### DIFF
--- a/askbot/deps/django_authopenid/views.py
+++ b/askbot/deps/django_authopenid/views.py
@@ -632,6 +632,7 @@ def signin(request, template_name='authopenid/signin.html'):
                     redirect_url = util.get_oauth2_starter_url(provider_name, csrf_token)
                     request.session['oauth2_csrf_token'] = csrf_token
                     request.session['provider_name'] = provider_name
+                    request.session['next_url'] = next_url
                     return HttpResponseRedirect(redirect_url)
                 except util.OAuthError, e:
                     logging.critical(unicode(e))


### PR DESCRIPTION
When user signed in for example from a question page to post an answer, s/he ended up on the front page instead of the question where s/he was.
