### PR TITLE
Adding ability to specify URL for closed dupe

### DIFF
--- a/askbot/models/__init__.py
+++ b/askbot/models/__init__.py
@@ -1658,11 +1658,11 @@ def user_close_question(
                     self,
                     question = None,
                     reason = None,
-                    timestamp = None
+                    timestamp = None,
+                    message = None
                 ):
     self.assert_can_close_question(question)
-    question.thread.set_closed_status(closed=True, closed_by=self, closed_at=timestamp, close_reason=reason)
-
+    question.thread.set_closed_status_dupe(closed=True, closed_by=self, closed_at=timestamp, close_reason=reason, close_message=message)
 @auto_now_timestamp
 def user_reopen_question(
                     self,

--- a/askbot/models/__init__.py
+++ b/askbot/models/__init__.py
@@ -1662,7 +1662,7 @@ def user_close_question(
                     message = None
                 ):
     self.assert_can_close_question(question)
-    question.thread.set_closed_status_dupe(closed=True, closed_by=self, closed_at=timestamp, close_reason=reason, close_message=message)
+    question.thread.set_closed_status(closed=True, closed_by=self, closed_at=timestamp, close_reason=reason, close_message=message)
 @auto_now_timestamp
 def user_reopen_question(
                     self,
@@ -1670,7 +1670,7 @@ def user_reopen_question(
                     timestamp = None
                 ):
     self.assert_can_reopen_question(question)
-    question.thread.set_closed_status(closed=False, closed_by=self, closed_at=timestamp, close_reason=None)
+    question.thread.set_closed_status(closed=False, closed_by=self, closed_at=timestamp, close_reason=None, close_message=None)
 
 @auto_now_timestamp
 def user_delete_post(

--- a/askbot/models/question.py
+++ b/askbot/models/question.py
@@ -848,17 +848,7 @@ class Thread(models.Model):
         self.update_summary_html() # regenerate question/thread summary html
         ####################################################################
 
-    def set_closed_status(self, closed, closed_by, closed_at, close_reason):
-        self.closed = closed
-        self.closed_by = closed_by
-        self.closed_at = closed_at
-        self.close_reason = close_reason
-        self.save()
-        self.invalidate_cached_data()
-    def set_closed_status_dupe(self, closed, closed_by, closed_at, close_reason, close_message):
-        """Adding ability to specify which question
-           the dupe is of
-        """
+    def set_closed_status(self, closed, closed_by, closed_at, close_reason, close_message):
         self.closed = closed
         self.closed_by = closed_by
         self.closed_at = closed_at

--- a/askbot/models/question.py
+++ b/askbot/models/question.py
@@ -615,6 +615,7 @@ class Thread(models.Model):
                                             null=True,
                                             blank=True
                                         )
+    close_message   = models.CharField(max_length=125)
     deleted = models.BooleanField(default=False, db_index=True)
 
     #denormalized data: the core approval of the posts is made
@@ -852,6 +853,17 @@ class Thread(models.Model):
         self.closed_by = closed_by
         self.closed_at = closed_at
         self.close_reason = close_reason
+        self.save()
+        self.invalidate_cached_data()
+    def set_closed_status_dupe(self, closed, closed_by, closed_at, close_reason, close_message):
+        """Adding ability to specify which question
+           the dupe is of
+        """
+        self.closed = closed
+        self.closed_by = closed_by
+        self.closed_at = closed_at
+        self.close_reason = close_reason
+        self.close_message = close_message
         self.save()
         self.invalidate_cached_data()
 

--- a/askbot/templates/close.html
+++ b/askbot/templates/close.html
@@ -11,6 +11,10 @@
             <strong>{% trans %}Reasons{% endtrans %}:</strong>
             {{ form.reason }}
         </p>
+        <p id="messageInput">
+            <strong>{% trans %}URL of duplicate{% endtrans %}:</strong><br/>
+            <input id="id_message" type="text" name="message" style="width:100%;"/>
+        </p>
         <p>
         <input type="submit" value="{% trans %}OK to close{% endtrans %}"/>
         <input id="btBack" type="button" value="{% trans %}Cancel{% endtrans %}"/>
@@ -22,6 +26,16 @@
         $().ready(function(){
             $('#btBack').bind('click', function(){ history.back(); });
         });
+    </script>
+    <script type="text/javascript">
+        document.getElementById("id_reason").onclick = function(){
+            if(document.getElementById("id_reason").value == 1){
+                document.getElementById("messageInput").style.display = "block";
+            }
+            else{
+                document.getElementById("messageInput").style.display = "none";
+            }
+        }
     </script>
 {% endblock %}
 <!-- end template close.html -->

--- a/askbot/templates/question/closed_question_info.html
+++ b/askbot/templates/question/closed_question_info.html
@@ -1,6 +1,6 @@
 <div class="question-status">
     <h3>{% trans %}Closed for the following reason{% endtrans %}
-      <b>{{ thread.get_close_reason_display() }}</b> {% trans %}by{% endtrans %}
+      <b>{{ thread.get_close_reason_display() }} of <a href="{{thread.close_message}}">{{thread.close_message}}</a></b> {% trans %}by{% endtrans %}
       <i><a href="{{ thread.closed_by.get_profile_url() }}">{{ thread.closed_by.username|escape }}</a> </i><br>
       {% trans closed_at=thread.closed_at %}close date {{closed_at}}{% endtrans %}</h3>
 </div>

--- a/askbot/views/commands.py
+++ b/askbot/views/commands.py
@@ -900,10 +900,11 @@ def close(request, id):#close question
             form = forms.CloseForm(request.POST)
             if form.is_valid():
                 reason = form.cleaned_data['reason']
-
+                message = request.POST.get('message',"")
                 request.user.close_question(
                                         question = question,
-                                        reason = reason
+                                        reason = reason,
+                                        message = message
                                     )
             return HttpResponseRedirect(question.get_absolute_url())
         else:


### PR DESCRIPTION
There is one structural change needed to make this addition work:

 close_message   = models.CharField(max_length=125)
As per this addition, the table for the thread needs a column added 

close_message character(125)