### PR TITLE
settings.ASKBOT_SITE_TO_DEFAULT_ASK_GROUP no longer used

### DIFF
--- a/askbot/management/commands/askbot_setup_sites.py
+++ b/askbot/management/commands/askbot_setup_sites.py
@@ -37,8 +37,6 @@ that you must take as well. These are detailed below:
         * <feed_id>: ('<feed_name>', <site_id>, <space_ids>)
         * where <space_ids> is a list of ids of Spaces whose questions should aggregate to this Feed (and hence to the referenced Site). The first ID identifies the primary Space.
     * if you want questions from your new Site to aggregate to the main KP Site, you should add the ID of your new Space to the list of Space IDs of the main Site's Feed in ASKBOT_FEEDS.
-    * add this to the ASKBOT_SITE_TO_DEFAULT_ASK_GROUP:
-        * <site_id>: <group_id>
 * run this managment command to create the objects and their relationships:
     * python manage.py askbot_setup_sites --settings=kp_settings
 * create <site_name>_settings.py file that imports * from the main settings 


### PR DESCRIPTION
Removed note about defining new site's default ask group via settings.ASKBOT_SITE_TO_DEFAULT_ASK_GROUP because this is no longer used
by the code. It's been deprecated in favour of per-site
settings.DEFAULT_ASK_GROUP_ID.
