### PR TITLE
Split Library JS Files from custom code

### DIFF
--- a/askbot/conf/forum_data_rules.py
+++ b/askbot/conf/forum_data_rules.py
@@ -377,6 +377,15 @@ settings.register(
 )
 
 settings.register(
+    livesettings.BooleanValue(
+        FORUM_DATA_RULES,
+        'COMMENTS_REVERSED',
+        default=False,
+        description=_('Reverse ordering of comments')
+    )
+)
+
+settings.register(
     livesettings.IntegerValue(
         FORUM_DATA_RULES,
         'MAX_COMMENT_LENGTH',

--- a/askbot/doc/source/changelog.rst
+++ b/askbot/doc/source/changelog.rst
@@ -1,6 +1,14 @@
 Changes in Askbot
 =================
 
+Development version (only in the repository)
+--------------------------------------------
+* Allowed reverse ordering of comments
+
+0.7.51 (Dec 15, 2014)
+---------------------
+* Bug fixes
+
 0.7.50 (Nov 1, 2014)
 --------------------
 * Added email alert for moderators `askbot_send_moderation_alerts`

--- a/askbot/media/bootstrap/css/bootstrap.css
+++ b/askbot/media/bootstrap/css/bootstrap.css
@@ -3516,6 +3516,7 @@ a.thumbnail:hover {
 }
 .modal-body {
   overflow-y: auto;
+  overflow-x: hidden;
   max-height: 400px;
   padding: 15px;
 }

--- a/askbot/media/js/askbot/live_search.js
+++ b/askbot/media/js/askbot/live_search.js
@@ -231,9 +231,9 @@ SearchDropMenu.prototype.isOpen = function () {
 };
 
 SearchDropMenu.prototype.show = function () {
-    var searchBar = this._element.prev();
-    var searchBarHeight = searchBar.outerHeight();
-    var topOffset = searchBar.offset().top + searchBarHeight;
+    var searchBar = this.getSearchWidget();
+    var searchBarHeight = searchBar.getWidgetHeight();
+    var topOffset = searchBar.getElement().offset().top + searchBarHeight;
     this._element.show();//show so that size calcs work
     var footerHeight = this._footer.outerHeight();
     var windowHeight = $(window).height();
@@ -541,6 +541,10 @@ FullTextSearch.prototype.refresh = function () {
 
 FullTextSearch.prototype.getSearchQuery = function () {
     return $.trim(this._query.val());
+};
+
+FullTextSearch.prototype.getWidgetHeight = function() {
+    return this._element.outerHeight();
 };
 
 /**

--- a/askbot/media/js/askbot/user/post_moderation_controls.js
+++ b/askbot/media/js/askbot/user/post_moderation_controls.js
@@ -106,7 +106,7 @@ PostModerationControls.prototype.getModHandler = function (action, items, optRea
                         junk = me.makeElement('div');
                         junk.attr('id', 'junk-mod');
                         junk.hide();
-                        $(document).append(junk);
+                        $('body').append(junk);
                     }
                     var a = me.makeElement('a');
                     a.attr('href', window.location.href);

--- a/askbot/media/js/askbot/utils/text_property_editor.js
+++ b/askbot/media/js/askbot/utils/text_property_editor.js
@@ -52,7 +52,7 @@ TextPropertyEditor.prototype.makeEditor = function () {
         me.saveData();
     });
 
-    $(document).append(editor.getElement());
+    $('body').append(editor.getElement());
     return editor;
 };
 

--- a/askbot/media/js/plugins/tinymce/plugins/askbot_attachment/editor_plugin.js
+++ b/askbot/media/js/plugins/tinymce/plugins/askbot_attachment/editor_plugin.js
@@ -33,7 +33,7 @@
         dialog.setPostUploadHandler(insertIntoDom);
         dialog.setInputId('askbot_attachment_input');
         dialog.setUrlInputTooltip(gettext('Or paste file url here'));
-        $(document).append(dialog.getElement());
+        $('body').append(dialog.getElement());
         return dialog;
     };
 

--- a/askbot/media/js/plugins/tinymce/plugins/askbot_imageuploader/editor_plugin.js
+++ b/askbot/media/js/plugins/tinymce/plugins/askbot_imageuploader/editor_plugin.js
@@ -32,7 +32,7 @@
         dialog.setPostUploadHandler(insertIntoDom);
         dialog.setUrlInputTooltip('Or paste image url here');
         dialog.setInputId('askbot_imageuploader_input');
-        $(document).append(dialog.getElement());
+        $('body').append(dialog.getElement());
         return dialog;
     };
 

--- a/askbot/media/style/style.css
+++ b/askbot/media/style/style.css
@@ -84,7 +84,8 @@ select,
 textarea,
 #askFormBar .questionTitleInput,
 .wmd-container,
-.folded-editor {
+.folded-editor,
+.mock-editor {
   border: #cce6ec 3px solid;
   height: 22px;
   font-size: 13px;
@@ -637,7 +638,7 @@ input[type="submit"].searchBtn {
   text-align: center;
   margin: 0;
   width: 48px;
-  background: -98px -37px url(../images/sprites.png) no-repeat;
+  background: -98px -36px url(../images/sprites.png) no-repeat;
   border-radius: 0;
   -ms-border-radius: 0;
   -moz-border-radius: 0;
@@ -687,7 +688,7 @@ input[type="submit"].searchBtn:hover {
   background-image: none;
   background-image: none;
   background-image: none;
-  background: -146px -37px url(../images/sprites.png) no-repeat;
+  background: url(../images/sprites.png) no-repeat -146px -36px !important;
 }
 input[type="button"].cancelSearchBtn {
   font-size: 30px !important;
@@ -1809,7 +1810,7 @@ ul#related-tags li {
   margin-top: 3px;
   margin-right: 7px;
 }
-.folded-editor {
+.folded-editor, .mock-editor {
   box-shadow: inset 0 0 3px 1px #aaa;
   -moz-box-shadow: inset 0 0 3px 1px #aaa;
   -webkit-box-shadow: inset 0 0 3px 1px #aaa;
@@ -1818,17 +1819,17 @@ ul#related-tags li {
   outline: none;
   width: 100%;
 }
-.folded-editor .editor-proper {
+.folded-editor .editor-proper, .mock-editor .editor-proper {
   display: none;
 }
-.folded-editor.unfolded {
+.folded-editor.unfolded, .mock-editor.unfolded {
   cursor: default;
   box-shadow: 0 0 0 0;
   -moz-box-shadow: 0 0 0 0;
   -webkit-box-shadow: 0 0 0 0;
 }
-.folded-editor p.prompt {
-  margin: 5px 8px;
+.folded-editor p.prompt, .mock-editor p.prompt {
+  margin: 5px 4px;
   display: block;
 }
 .ask-page .folded-editor {
@@ -2301,13 +2302,6 @@ ul#related-tags li {
 .question-page .question-img-favorite:hover {
   background: url(../images/vote-favorite-on.png);
 }
-.question-page div.comments {
-  padding: 0;
-}
-.question-page div.comments.empty {
-  margin-top: -34px;
-  float: left;
-}
 .question-page h2.comment-title {
   color: #7ea9b3;
   font-weight: bold;
@@ -2317,9 +2311,14 @@ ul#related-tags li {
   padding-left: 0;
   width: 200px;
 }
+.question-page .comments.empty.ordering-forward {
+  margin-top: -35px;
+  float: left;
+}
 .question-page .comments {
   font-size: 12px;
   clear: both;
+  padding: 0;
 }
 .question-page .comments .truncated-post:nth-last-child(3) {
   float: left;
@@ -2353,11 +2352,17 @@ ul#related-tags li {
 .question-page .comments .controls a:hover {
   text-decoration: none;
 }
-.question-page .comments .button {
+.question-page .comments .js-open-editor-btn, .question-page .comments .js-load-comments-btn {
   color: #988e4c;
   font-size: 11px;
   padding: 3px;
   cursor: pointer;
+}
+.question-page .comments .js-open-editor-btn.new-comment-box {
+  padding: 0 14px 0 29px;
+}
+.question-page .comments .js-open-editor-btn.new-comment-box .mock-editor {
+  height: 50px;
 }
 .question-page .comments a {
   background-color: inherit;
@@ -2376,14 +2381,17 @@ ul#related-tags li {
   font-size: 13px;
   height: 54px;
   line-height: 1.3;
-  margin: -1px 0 0 1px;
+  margin: 0;
   outline: none;
   overflow: auto;
-  padding: 5px 19px 2px 3px;
-  width: 99.6%;
+  padding: 5px 19px 2px 6px;
+  width: 100%;
 }
 .question-page .comments .wmd-container textarea {
   border: none;
+  box-shadow: inset 0 0 3px 1px #aaa;
+  -moz-box-shadow: inset 0 0 3px 1px #aaa;
+  -webkit-box-shadow: inset 0 0 3px 1px #aaaaaa;
 }
 .question-page .comments .transient-comment {
   margin-bottom: 3px;
@@ -2475,19 +2483,31 @@ ul#related-tags li {
 .question-page .comments .comment-body {
   line-height: 1.3;
   margin: 3px 26px 0 0;
-  padding: 5px 3px;
+  padding: 5px 3px 0;
   color: #666;
   font-size: 13px;
 }
-.question-page .comments .comment-body .edit {
+.question-page .comments .comment-body p {
+  font-size: 13px;
+  line-height: 1.3;
+  margin-bottom: 3px;
+  padding: 0;
+}
+.question-page .comments .comment-body p:last-child {
+  margin-bottom: 0;
+}
+.question-page .comments .comment-controls {
+  padding-left: 3px;
+}
+.question-page .comments .edit {
   padding-left: 6px;
 }
-.question-page .comments .comment-body .convert-comment {
+.question-page .comments .convert-comment {
   display: inline;
   white-space: nowrap;
   padding-left: 0px;
 }
-.question-page .comments .comment-body .convert-comment input {
+.question-page .comments .convert-comment input {
   background: none;
   padding: 0px;
   color: #1B79BD;
@@ -2495,9 +2515,9 @@ ul#related-tags li {
   height: 13px;
   width: auto;
   font-family: Arial;
-  font-size: 13px;
+  font-size: 11px;
   font-weight: normal;
-  line-height: 13px;
+  line-height: 15px;
   margin: 0 0 3px 8px;
   vertical-align: middle;
   -webkit-box-shadow: 0 0 0 #929292;
@@ -2507,15 +2527,9 @@ ul#related-tags li {
   -moz-text-shadow: 0 0 0 #929292;
   -webkit-text-shadow: 0 0 0 #929292;
 }
-.question-page .comments .comment-body .convert-comment input:hover {
+.question-page .comments .convert-comment input:hover {
   text-decoration: underline;
   cursor: pointer;
-}
-.question-page .comments .comment-body p {
-  font-size: 13px;
-  line-height: 1.3;
-  margin-bottom: 3px;
-  padding: 0;
 }
 .question-page .comments .comment-delete {
   float: right;
@@ -2604,10 +2618,10 @@ ul#related-tags li {
 .question-page .answered-by-owner {
   background: #F1F1FF;
 }
-.question-page .answered-by-owner .comments .button {
+.question-page .answered-by-owner .comments {
   background-color: #E6ECFF;
 }
-.question-page .answered-by-owner .comments {
+.question-page .answered-by-owner .comments .js-load-comments-btn, .question-page .answered-by-owner .comments .js-open-editor-btn {
   background-color: #E6ECFF;
 }
 .question-page .answer-img-accept {

--- a/askbot/media/style/style.less
+++ b/askbot/media/style/style.less
@@ -68,7 +68,8 @@ select,
 textarea,
 #askFormBar .questionTitleInput,
 .wmd-container,
-.folded-editor {
+.folded-editor,
+.mock-editor {
     border: #cce6ec 3px solid;
     height: 22px;
     font-size: 13px;
@@ -683,7 +684,7 @@ input[type="submit"].searchBtn {
     text-align: center;
     margin: 0;
     width: 48px;
-    .sprites(-98px,-37px);
+    .sprites(-98px,-36px);
     .rounded-corners(0);
     .box-shadow(0, 0, 0);
     cursor:pointer;
@@ -732,7 +733,7 @@ input[type="submit"].searchBtn:hover {
     background-image: none;
     background-image: none;
     background-image: none;
-    .sprites(-98px-48,-37px);
+    background: url(../images/sprites.png) no-repeat -146px -36px !important;
 }
 
 input[type="button"].cancelSearchBtn {
@@ -1942,7 +1943,8 @@ ul#related-tags li {
     margin-right:7px;
 }
 
-.folded-editor {
+.folded-editor,
+.mock-editor {
     box-shadow: inset 0 0 3px 1px #aaa;
     -moz-box-shadow: inset 0 0 3px 1px #aaa;
     -webkit-box-shadow: inset 0 0 3px 1px #aaa;
@@ -1962,7 +1964,7 @@ ul#related-tags li {
         -webkit-box-shadow: 0 0 0 0;
     }
     p.prompt {
-        margin: 5px 8px;
+        margin: 5px 4px;
         display: block;
     }
 }
@@ -2475,13 +2477,6 @@ ul#related-tags li {
     .question-img-favorite:hover {
         background: url(../images/vote-favorite-on.png)
     }
-    div.comments {
-        padding: 0;
-    }
-    div.comments.empty {
-        margin-top: -34px;
-        float: left;
-    }
     h2.comment-title {
        color: @section-title;
        font-weight: bold;
@@ -2491,9 +2486,14 @@ ul#related-tags li {
        padding-left: 0;
        width:200px;
     }
+    .comments.empty.ordering-forward {
+        margin-top: -35px;
+        float: left;
+    }
     .comments {
         font-size: 12px;    
         clear: both;
+        padding: 0;
 
         .truncated-post:nth-last-child(3) {
             float: left;
@@ -2528,12 +2528,22 @@ ul#related-tags li {
             text-decoration: none;
         }
 
-        .button {
+        .js-open-editor-btn,
+        .js-load-comments-btn {
             color: #988e4c;
             font-size: 11px;
             padding: 3px;
             cursor: pointer;
         }
+
+        .js-open-editor-btn.new-comment-box {
+            padding: 0 14px 0 29px;
+            .mock-editor {
+                height: 50px;
+            }
+        }
+
+
         a {
             background-color: inherit;
             color: @link;
@@ -2553,14 +2563,17 @@ ul#related-tags li {
             font-size: 13px;
             height: 54px;
             line-height: 1.3;
-            margin: -1px 0 0 1px;
+            margin: 0;
             outline: none;
             overflow:auto;
-            padding: 5px 19px 2px 3px;
-            width: 99.6%;
+            padding: 5px 19px 2px 6px;
+            width: 100%;
         }
         .wmd-container textarea {
             border: none;
+            box-shadow: inset 0 0 3px 1px #aaa;
+            -moz-box-shadow: inset 0 0 3px 1px #aaa;
+            -webkit-box-shadow: inset 0 0 3px 1px #aaa
         }
         .transient-comment {
             margin-bottom: 3px; /* match paragraph style */
@@ -2653,48 +2666,53 @@ ul#related-tags li {
         .comment-body {
             line-height: 1.3;
             margin: 3px 26px 0 0;
-            padding: 5px 3px;
+            padding: 5px 3px 0;
             color: #666;
             font-size:13px;
-
-            .edit{
-                padding-left:6px;
+            p {
+                font-size:13px;
+                line-height:1.3;
+                margin-bottom: 3px;
+                padding: 0;
             }
-
-            .convert-comment {
-                display: inline;
-                white-space: nowrap;
-                padding-left: 0px;
-                input {
-                    background: none;
-                    padding: 0px;
-                    color: #1B79BD;
-                    border:none;
-                    height: 13px;
-                    width:auto;
-                    font-family: Arial;
-                    font-size: 13px;
-                    font-weight: normal;
-                    line-height: 13px;
-                    margin: 0 0 3px 8px;
-                    vertical-align: middle;
-                    .box-shadow(0, 0, 0);
-                    .text-shadow(0, 0, 0);
-                }
-
-                input:hover {
-                    text-decoration: underline;
-                    cursor: pointer;
-                }
+            p:last-child {
+                margin-bottom: 0;
             }
-
         }
 
-        .comment-body p{
-            font-size:13px;
-            line-height:1.3;
-            margin-bottom: 3px;
-            padding: 0;
+        .comment-controls {
+            padding-left: 3px;
+        }
+
+        .edit {
+            padding-left:6px;
+        }
+
+        .convert-comment {
+            display: inline;
+            white-space: nowrap;
+            padding-left: 0px;
+            input {
+                background: none;
+                padding: 0px;
+                color: #1B79BD;
+                border:none;
+                height: 13px;
+                width:auto;
+                font-family: Arial;
+                font-size: 11px;
+                font-weight: normal;
+                line-height: 15px;
+                margin: 0 0 3px 8px;
+                vertical-align: middle;
+                .box-shadow(0, 0, 0);
+                .text-shadow(0, 0, 0);
+            }
+
+            input:hover {
+                text-decoration: underline;
+                cursor: pointer;
+            }
         }
 
         .comment-delete {
@@ -2800,11 +2818,12 @@ ul#related-tags li {
     .answered-by-owner {
         background: #F1F1FF;
 
-        .comments .button {
-            background-color: #E6ECFF;
-        }
         .comments {
             background-color: #E6ECFF;
+            .js-load-comments-btn,
+            .js-open-editor-btn {
+                background-color: #E6ECFF;
+            }
         }
     }
 

--- a/askbot/templates/ask.html
+++ b/askbot/templates/ask.html
@@ -70,7 +70,7 @@
 
             if (askbot['data']['userIsAuthenticated']) {
                 var draftHandler = new DraftQuestion();
-                draftHandler.decorate($(document));
+                draftHandler.decorate($('body'));
                 window.onbeforeunload = function() {
                     var saveHandler = draftHandler.getSaveHandler();
                     saveHandler(true);

--- a/askbot/templates/macros.html
+++ b/askbot/templates/macros.html
@@ -331,28 +331,85 @@
 {# Warning! Any changes to the comment markup here must be duplicated in post.js
 for the purposes of the AJAX comment editor #}
 
-{%- macro add_or_show_comments_button(post = None, max_comments = None, widget_id = None) -%}
+{%- macro comments_widget_buttons(post = None, max_comments = None) -%}
     {% if post.comment_count > max_comments %}
-        {% set remaining_comment_count = post.comment_count - max_comments %}
+        {% if settings.COMMENTS_REVERSED == False %}
+            <a class="hidden js-open-editor-btn">{% trans %}add a comment{% endtrans %}</a>
+        {% endif %}
+        <a class="js-load-comments-btn">
+            {% if settings.COMMENTS_REVERSED %}
+                {% trans %}load older comments{% endtrans %}
+            {% else %}
+                {% trans %}see more comments{% endtrans %}
+            {% endif %}
+        </a>
     {% else %}
-        {% set remaining_comment_count = 0 %}
+        {% if settings.COMMENTS_REVERSED == False %}
+            <a class="js-open-editor-btn">{% trans %}add a comment{% endtrans %}</a>
+        {% endif %}
     {% endif %}
-    <a id="add-comment-to-post-{{post.id}}" class="button"></a>
-    <script type="text/javascript">
-        askbot['data']['{{widget_id}}'] = {
-            truncated: {% if post.comment_count > max_comments %}true{% else %}false{% endif %}
-        };
-        askbot['functions']['renderAddCommentButton'](
-                                                '{{post.id}}',
-                                                {{remaining_comment_count}}
-                                            );
-    </script>
 {%- endmacro -%}
 
 {%- macro csrf_middleware_token(csrf_token) -%}
     <div style="display: none;">
         <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}" />
     </div>
+{%- endmacro -%}
+
+{%- macro comment_widget(comment) -%}
+    {# Warning! Any changes to the comment markup must be duplicated in post.js
+       for the purposes of the AJAX comment editor #}
+    <div class="comment" data-comment-id="{{ comment.id }}">
+        <div class="comment-votes">
+            {% if comment.score > 0 %}
+                <div 
+                    id="comment-img-upvote-{{ comment.id }}" 
+                    class="upvote"
+                >{{ comment.score }}</div>
+                <script type="text/javascript">
+                    askbot['functions']['renderPostVoteButtons']('comment', '{{ comment.id }}');
+                </script>
+            {% else %}
+                <div class="upvote"></div>
+            {% endif %}
+        </div>
+        <div class="comment-content">
+            <div id="post-{{ comment.id }}-delete" class="comment-delete">
+                <span class="delete-icon" title="{% trans %}delete this comment{% endtrans %}"></span>
+            </div>
+            {% if comment.needs_moderation() %}
+                <p class="moderated">{% trans %}This post is awaiting moderation{% endtrans %}</p>
+            {% endif %}
+            <div class="comment-body">
+                {{ comment.summary }}
+            </div>
+            <div class="comment-controls">
+                <a 
+                    class="author"
+                    href="{{ comment.author.get_profile_url() }}"
+                >{{ comment.author.username|escape }}</a>
+                <span class="age">&nbsp;({{ timeago(comment.added_at) }})</span>
+                <a 
+                    id="post-{{ comment.id }}-edit"
+                    class="edit"
+                >{% trans %}edit{% endtrans %}</a>
+                <form 
+                    action="{% url comment_to_answer %}"
+                    method="POST"
+                    accept-charset="utf-8"
+                    class='convert-comment'
+                >
+                    <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
+                    <input type="hidden" value="{{ comment.id }}" name="comment_id">
+                    <input type="submit" value="{% trans %}convert to answer{% endtrans %}">
+                </form>
+            </div>
+        </div>
+    </div>
+    <script type="text/javascript">
+        askbot['functions']['hideConvertLinks']();
+        askbot['functions']['renderPostControls']('{{ comment.id }}');
+    </script>
 {%- endmacro -%}
 
 {%- macro post_comments_widget(
@@ -372,103 +429,30 @@ for the purposes of the AJAX comment editor #}
         {% set comments = post.get_cached_comments()[:max_comments] %}
     {% endif %}
     {% set comments_count = comments|length %}
-    {% if comments_count > 0 %}
+    {% if comments_count > 0 or settings.COMMENTS_REVERSED %}
         <h2 class="comment-title">{% trans %}Comments{% endtrans %}</h2>
         <div class="clean"></div> 
     {% endif %}
-    {% set widget_id = 'comments-for-' + post.post_type + '-' + post.id|string %}
-    <div class="comments{% if comments_count == 0 %} empty{% endif %}" id="{{ widget_id }}">
+    <div class="comments{% if comments_count == 0 %} empty{% endif %} ordering-{% if settings.COMMENTS_REVERSED %}reversed{% else %}forward{% endif %}" 
+        data-parent-post-type="{{ post.post_type }}"
+        data-parent-post-id="{{ post.id }}"
+    >
+        {% if settings.COMMENTS_REVERSED %}
+            <div class="js-open-editor-btn new-comment-box">
+                {% set prompt=gettext('add a comment...') %}
+                {% include "widgets/mock_editor.html" %}
+            </div>
+        {% endif %}
         <div class="content">
             {% for comment in comments %}
-                {# Warning! Any changes to the comment markup IN THIS `FOR` LOOP must be duplicated in post.js
-                   for the purposes of the AJAX comment editor #}
-                <div class="comment" 
-                    id="comment-{{comment.id}}"
-                    data-post-id="{{ comment.id }}"
-                >
-                    <div class="comment-votes">
-                        {% if comment.score > 0 %}
-                            <div 
-                                id="comment-img-upvote-{{comment.id}}" 
-                                class="upvote"
-                            >{{comment.score}}</div>
-                            <script type="text/javascript">
-                                askbot['functions']['renderPostVoteButtons']('comment', '{{comment.id}}');
-                            </script>
-                        {% else %}
-                            <div class="upvote"></div>
-                        {% endif %}
-                    </div>
-                    <div class="comment-content">
-                        <div 
-                            id="post-{{comment.id}}-delete"
-                            class="comment-delete"
-                        >
-                            <span 
-                                class="delete-icon"
-                                title="{% trans %}delete this comment{% endtrans %}"
-                            ></span>
-                        </div>
-                        {% if comment.needs_moderation() %}
-                            <p class="moderated">{% trans %}This post is awaiting moderation{% endtrans %}</p>
-                        {% endif %}
-                        <div class="comment-body">
-                            {{ comment.summary }}
-                            <a 
-                                class="author"
-                                href="{{comment.author.get_profile_url()}}"
-                            >{{comment.author.username|escape}}</a>
-                            <span class="age">&nbsp;({{ timeago(comment.added_at) }})</span>
-                            <a 
-                                id="post-{{comment.id}}-edit"
-                                class="edit"
-                            >{% trans %}edit{% endtrans %}</a>
-                            <form 
-                                action="{% url comment_to_answer %}"
-                                method="POST"
-                                accept-charset="utf-8"
-                                class='convert-comment'
-                            >
-                                <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
-                                <input type="hidden" value="{{comment.id}}" name="comment_id">
-                                <input type="submit" value="{% trans %}convert to answer{% endtrans %}">
-                            </form>
-                        </div>
-                    </div>
-                </div>
-                <script type="text/javascript">
-                    askbot['functions']['hideConvertLinks']();
-                    askbot['functions']['renderPostControls']('{{comment.id}}');
-                </script>
+                {{ comment_widget(comment) }}
             {% endfor %}
         </div>
         <div class="controls">
-            {% if show_post == post and show_comment %}
-                {% if show_comment_position > max_comments %}
-                    {{
-                        add_or_show_comments_button(
-                                            post = post,
-                                            max_comments = show_comment_position,
-                                            widget_id = widget_id
-                                        )
-                    }}
-                {% else %}
-                    {{
-                        add_or_show_comments_button(
-                                            post = post,
-                                            max_comments = max_comments,
-                                            widget_id = widget_id
-                                        )
-                    }}
-                {% endif %}
+            {% if show_post == post and show_comment and show_comment_position > max_comments %}
+                {{ comments_widget_buttons(post=post, max_comments=show_comment_position) }}
             {% else %}
-                {{
-                    add_or_show_comments_button(
-                                        post = post,
-                                        max_comments = max_comments,
-                                        widget_id = widget_id
-                                    )
-                }}
+                {{ comments_widget_buttons(post=post, max_comments=max_comments) }}
             {% endif %}
         </div>
     </div>

--- a/askbot/templates/question.html
+++ b/askbot/templates/question.html
@@ -267,15 +267,6 @@
                     }
                 }
             }
-            function render_add_comment_button(post_id, extra_comment_count){
-                if (extra_comment_count > 0){
-                    var text = "{% trans %}see more comments{% endtrans%}";
-                } else {
-                    var text = "{% trans %}add a comment{% endtrans %}";
-                }
-                var add_comment_btn = document.getElementById('add-comment-to-post-' + post_id);
-                add_comment_btn.innerHTML = text;
-            }
 
             function render_add_answer_button(){
                 var add_answer_btn = document.getElementById('add-answer-btn');
@@ -321,7 +312,6 @@
             askbot['functions'] = askbot['functions'] || {};
             askbot['functions']['renderPostVoteButtons'] = render_vote_buttons;
             askbot['functions']['renderPostControls'] = render_post_controls;
-            askbot['functions']['renderAddCommentButton'] = render_add_comment_button;
             askbot['functions']['renderAddAnswerButton'] = render_add_answer_button;
             askbot['functions']['hideConvertLinks'] = hide_convert_links;
             askbot['functions']['hideConvertAnswerLinks'] = hide_convert_answer_links;
@@ -346,6 +336,14 @@
     {% include "question/sidebar.html" %}
 {% endblock %}
 {% block endjs %}
+    {% if request.user.is_authenticated() %}
+        {% from "macros.html" import comment_widget %}
+        {% spaceless %}
+        <div class="comment-template" style="display: none">
+            {{ comment_widget(blank_comment) }}
+        </div>
+        {% endspaceless %}
+    {% endif %}
     <script type='text/javascript'>
         {# not compressable #}
         var maxCommentLength = {{settings.MAX_COMMENT_LENGTH}};

--- a/askbot/templates/question/javascript.html
+++ b/askbot/templates/question/javascript.html
@@ -1,5 +1,6 @@
 <script type='text/javascript'>
     (function() {
+        askbot['settings']['commentsReversed'] = {{ settings.COMMENTS_REVERSED|as_js_bool }};
         //make images always fit the screen
         var images = $('.question-page .post-body img');
         //these breakpoints must match those in css
@@ -63,7 +64,7 @@
         if (askbot['data']['userIsAuthenticated']) {
             var draftHandler = new DraftAnswer();
             draftHandler.setThreadId({{ thread.id }});
-            draftHandler.decorate($(document));
+            draftHandler.decorate($('body'));
         }
 
         var expanders = $('.expander');

--- a/askbot/templates/users.html
+++ b/askbot/templates/users.html
@@ -102,7 +102,7 @@
                 var group_join_btn = new GroupJoinButton();
                 group_join_btn.decorate($('.group-join-btn'));
                 //setup WMD editor
-                if (askbot['data']['userIsAdminOrMod'] === true){
+                if (askbot['data']['userIsAdminOrMod']){
                     //todo: this is kind of Attacklab.init ... should not be here
                     Attacklab.wmd = function(){
                         Attacklab.loadEnv = function(){

--- a/askbot/templates/widgets/ask_form.html
+++ b/askbot/templates/widgets/ask_form.html
@@ -7,7 +7,7 @@
                 <span class="form-error">{{ form.title.errors }}</span>
             {% endif %}
         </label>
-        <div id="askFormBar">
+        <div id="askFormBar" class="search-bar">
             <input id="id_title" class="questionTitleInput" name="title" autocomplete="off"
                 value="{% if form.initial.title %}{{form.initial.title|escape}}{% endif %}"/>
         </div>

--- a/askbot/templates/widgets/mock_editor.html
+++ b/askbot/templates/widgets/mock_editor.html
@@ -1,0 +1,3 @@
+<div class="mock-editor">
+    <p class="prompt">{{ prompt }}</p>
+</div>

--- a/askbot/urls.py
+++ b/askbot/urls.py
@@ -322,7 +322,7 @@ urlpatterns = patterns('',
         name='delete_comment'
     ),
     service_url(#ajax only
-        r'^comment/get_text/$',
+        r'^comment/get-text/$',
         views.readers.get_comment,
         name='get_comment'
     ),

--- a/askbot/views/readers.py
+++ b/askbot/views/readers.py
@@ -42,6 +42,7 @@ from askbot.forms import GetDataForPostForm
 from askbot.utils.loading import load_module
 from askbot import conf
 from askbot import models
+from askbot.models.post import MockPost
 from askbot.models.tag import Tag
 from askbot import const
 from askbot.startup_procedures import domain_is_bad
@@ -512,7 +513,6 @@ def question(request, id):#refactor - long subroutine. display question body, an
                                 sort_method=answer_sort_method,
                                 user=request.user
                             )
-
     user_votes = {}
     user_post_id_list = list()
     #todo: cache this query set, but again takes only 3ms!
@@ -628,35 +628,36 @@ def question(request, id):#refactor - long subroutine. display question body, an
         group_read_only = False
 
     data = {
-        'is_cacheable': False,#is_cacheable, #temporary, until invalidation fix
-        'long_time': const.LONG_TIME,#"forever" caching
-        'page_class': 'question-page',
         'active_tab': 'questions',
+        'answer' : answer_form,
+        'answers' : page_objects.object_list,
+        'answer_count': thread.get_answer_count(request.user),
+        'blank_comment': MockPost(post_type='comment', author=request.user),#data for the js comment template
+        'category_tree_data': askbot_settings.CATEGORY_TREE,
+        'editor_is_unfolded': answer_form.has_data(),
+        'favorited' : favorited,
+        'group_read_only': group_read_only,
+        'is_cacheable': False,#is_cacheable, #temporary, until invalidation fix
+        'language_code': translation.get_language(),
+        'long_time': const.LONG_TIME,#"forever" caching
+        'new_answer_allowed': new_answer_allowed,
+        'oldest_answer_id': thread.get_oldest_answer_id(request.user),
+        'page_class': 'question-page',
+        'paginator_context' : paginator_context,
+        'previous_answer': previous_answer,
+        'published_answer_ids': published_answer_ids,
         'question' : question_post,
+        'show_comment': show_comment,
+        'show_comment_position': show_comment_position,
+        'show_post': show_post,
+        'similar_threads' : thread.get_similar_threads(),
+        'tab_id' : answer_sort_method,
         'thread': thread,
         'thread_is_moderated': thread.is_moderated(),
         'user_is_thread_moderator': thread.has_moderator(request.user),
-        'published_answer_ids': published_answer_ids,
-        'answer' : answer_form,
-        'editor_is_unfolded': answer_form.has_data(),
-        'answers' : page_objects.object_list,
-        'answer_count': thread.get_answer_count(request.user),
-        'category_tree_data': askbot_settings.CATEGORY_TREE,
         'user_votes': user_votes,
         'user_post_id_list': user_post_id_list,
         'user_can_post_comment': user_can_post_comment,#in general
-        'new_answer_allowed': new_answer_allowed,
-        'oldest_answer_id': thread.get_oldest_answer_id(request.user),
-        'previous_answer': previous_answer,
-        'tab_id' : answer_sort_method,
-        'favorited' : favorited,
-        'similar_threads' : thread.get_similar_threads(),
-        'language_code': translation.get_language(),
-        'paginator_context' : paginator_context,
-        'show_post': show_post,
-        'show_comment': show_comment,
-        'show_comment_position': show_comment_position,
-        'group_read_only': group_read_only,
     }
     #shared with ...
     if askbot_settings.GROUPS_ENABLED:


### PR DESCRIPTION
To make refacroring more easy, we moved the library files to a separate folder,
New structure:
- media/js
  - libs (Libraries like jQuery, Less, ...)
  - plugins (External Plugins like Tinymce, WMD, Fancybox,  ...)
  - askbot (all custom code)

_list of javascript files that are not used_
- jquery-1.4.3.js
- jquery-migrate-1.2.1.js
- jquery.animate-colors.js
- jquery.i18n.js
- jquery.fancybox-1.3.4
- autocompleter.js
- jquery-fieldselection.js
- jquery.ajaxfileupload.js
- jquery.openid.js (directly in js folder)
- output-words.js
