### PR TITLE
fix caret moving to incorrect place after completing a tag

### DIFF
--- a/askbot/media/js/libs/autocompleter.js
+++ b/askbot/media/js/libs/autocompleter.js
@@ -675,7 +675,7 @@ AutoCompleter.prototype.selectItem = function($li) {
 
     this.setValue(displayValue);
 
-    this.setCaret(displayValue.length);
+    this.setCaret(this._element.val().length);
     this.callHook('onItemSelect', { value: value, data: data });
     this.finish();
 };


### PR DESCRIPTION
If you autocomplete a tag, for example "kafka" and after that autocomplete a tag "book" then caret will be at the fourth symbol like this "kafk|a, book", which is incorrect
