### PR TITLE
Correctly hide cancelled comments

### DIFF
--- a/askbot/media/js/askbot/post.js
+++ b/askbot/media/js/askbot/post.js
@@ -2552,7 +2552,11 @@ Comment.prototype.setContent = function (data) {
         this._convert_link = new CommentConvertLink(this._data.id);
         oldConvertLink.getElement().replaceWith(this._convert_link.getElement());
     }
-    this._blank = false;
+    if (this.getId()) {
+        this._blank = false;
+    } else {
+        this._blank = true;
+    }
 };
 
 Comment.prototype.dispose = function () {
@@ -2790,7 +2794,7 @@ PostCommentsWidget.prototype.getAllowEditHandler = function () {
     };
 };
 
-PostCommentsWidget.prototype.getOpenEditorHandler = function(button) {
+PostCommentsWidget.prototype.getOpenEditorHandler = function (button) {
     var me = this;
     return function () {
         //if user can't post, we tell him something and refuse

--- a/askbot/templates/macros.html
+++ b/askbot/templates/macros.html
@@ -359,7 +359,7 @@ for the purposes of the AJAX comment editor #}
 {%- macro comment_widget(comment) -%}
     {# Warning! Any changes to the comment markup must be duplicated in post.js
        for the purposes of the AJAX comment editor #}
-    <div class="comment js-comment" data-comment-id="{{ comment.id }}">
+    <div class="comment js-comment"{% if comment.id %} data-comment-id="{{ comment.id }}"{% endif %}>
         <div class="comment-votes">
             {% if comment.score > 0 %}
                 <div 


### PR DESCRIPTION
There's currently a bug with adding a comment to question or an answer:
###### Steps to reproduce:
- click add comment
- click cancel button on shown editor
###### Expected result:

Form hides, no comment added
###### Actual result:

Empty comment is added to dom, then if page is refreshed it's not there anymore

This PR fixes this bug, however I'm not totally sure if it's affecting anything else.
