### PR TITLE
pass event object through makeKeyHandler

### DIFF
--- a/askbot/media/js/utils.js
+++ b/askbot/media/js/utils.js
@@ -225,7 +225,7 @@ var makeKeyHandler = function (key, callback) {
     return function (e) {
         if ((e.which && e.which === key) || (e.keyCode && e.keyCode === key)) {
             if (!e.shiftKey) {
-                callback();
+                callback(e);
                 return false;
             }
         }


### PR DESCRIPTION
currently there's an error thrown if you try to edit comment and then cancel it by pressing escape button. `Uncaught TypeError: Cannot read property 'preventDefault' of undefined`
this happens because `EditCommentForm.prototype.getCancelHandler()` is used for both click handler and keyup handler where it tries to do evt.preventDefault();
this fixes it.