### PR TITLE
Added blank=True to field definition for Group.logo_url

### DIFF
--- a/askbot/models/user.py
+++ b/askbot/models/user.py
@@ -543,7 +543,7 @@ class Group(AuthGroup):
         (MODERATED, 'moderated'),
         (CLOSED, 'closed'),
     )
-    logo_url = models.URLField(null=True)
+    logo_url = models.URLField(null=True, blank=True)
     description = models.OneToOneField(
                     'Post', related_name='described_group',
                     null=True, blank=True


### PR DESCRIPTION
This will allow us to edit Groups via admin even if they have no logo_url.