### PR TITLE
New askbot setting: text for the login/signup hyperlink

### DIFF
--- a/askbot/conf/site_settings.py
+++ b/askbot/conf/site_settings.py
@@ -100,6 +100,17 @@ settings.register(
 )
 
 settings.register(
+    livesettings.StringValue(
+        QA_SITE_SETTINGS,
+        'LOGIN_SIGNUP_LINK_TEXT',
+        default=_('Hi there! Please sign in'),
+        description=_('Log in/Sign up text'),
+        help_text=_('Text for the link to log in/sign up.'),
+        localized=True
+    )
+)
+
+settings.register(
     livesettings.BooleanValue(
         QA_SITE_SETTINGS,
         'ENABLE_GREETING_FOR_ANON_USER',

--- a/askbot/conf/words.py
+++ b/askbot/conf/words.py
@@ -18,17 +18,6 @@ WORDS = ConfigurationGroup(
 settings.register(
     values.StringValue(
         WORDS,
-        'WORDS_LOGIN_SIGNUP_LINK_TEXT',
-        default=_('Hi there! Please sign in'),
-        description=_('Log in/Sign up text'),
-        help_text=_('Text for the link to log in/sign up.'),
-        localized=True
-    )
-)
-
-settings.register(
-    values.StringValue(
-        WORDS,
         'WORDS_ASK_YOUR_QUESTION',
         default=_('Ask Your Question'),
         description=_('Ask Your Question'),

--- a/askbot/conf/words.py
+++ b/askbot/conf/words.py
@@ -18,6 +18,17 @@ WORDS = ConfigurationGroup(
 settings.register(
     values.StringValue(
         WORDS,
+        'WORDS_LOGIN_SIGNUP_LINK_TEXT',
+        default=_('Hi there! Please sign in'),
+        description=_('Log in/Sign up text'),
+        help_text=_('Text for the link to log in/sign up.'),
+        localized=True
+    )
+)
+
+settings.register(
+    values.StringValue(
+        WORDS,
         'WORDS_ASK_YOUR_QUESTION',
         default=_('Ask Your Question'),
         description=_('Ask Your Question'),

--- a/askbot/templates/widgets/user_navigation.html
+++ b/askbot/templates/widgets/user_navigation.html
@@ -18,7 +18,7 @@
     <a 
         class="login"
         href="{{ settings.LOGIN_URL }}?next={{request.path|clean_login_url|escape}}{% if space %}&amp;space={{ space }}{% endif %}"
-    >{{ settings.WORDS_LOGIN_SIGNUP_LINK_TEXT }}</a>
+    >{{ settings.LOGIN_SIGNUP_LINK_TEXT }}</a>
 {% endif %}
 {% if request.user.is_authenticated() and request.user.is_administrator() %}
     <a class="settings" href="{% url site_settings %}">{% trans %}settings{% endtrans %}</a>

--- a/askbot/templates/widgets/user_navigation.html
+++ b/askbot/templates/widgets/user_navigation.html
@@ -18,7 +18,7 @@
     <a 
         class="login"
         href="{{ settings.LOGIN_URL }}?next={{request.path|clean_login_url|escape}}{% if space %}&amp;space={{ space }}{% endif %}"
-    >{% trans %}Hi there! Please sign in{% endtrans %}</a>
+    >{{ settings.WORDS_LOGIN_SIGNUP_LINK_TEXT }}</a>
 {% endif %}
 {% if request.user.is_authenticated() and request.user.is_administrator() %}
     <a class="settings" href="{% url site_settings %}">{% trans %}settings{% endtrans %}</a>


### PR DESCRIPTION
Created new askbot setting for the login/signup link text (defaulted to the string that used to be in the template) and use it in the template.

Trello ticket: [Can we change "Hi there! Please sign in" to "Click here to log in or register"](
https://trello.com/c/EqSRly6G/558-can-we-change-hi-there-please-sign-in-to-click-here-to-log-in-or-register)