### PR TITLE
New askbot setting ASK_BUTTON_TEXT

### DIFF
--- a/askbot/conf/forum_data_rules.py
+++ b/askbot/conf/forum_data_rules.py
@@ -162,6 +162,19 @@ settings.register(
 )
 
 settings.register(
+    livesettings.values.StringValue(
+        FORUM_DATA_RULES,
+        'ASK_BUTTON_TEXT',
+        description=_('Text for big Ask button'),
+        default='',
+        localized=True,
+        help_text=_(
+            'If big Ask button enabled, over-ride its text here.'
+        )
+    )
+)
+
+settings.register(
     livesettings.BooleanValue(
         FORUM_DATA_RULES,
         'ENABLE_VIDEO_EMBEDDING',

--- a/askbot/templates/widgets/ask_button.html
+++ b/askbot/templates/widgets/ask_button.html
@@ -16,7 +16,9 @@
         id="askButton"
         class="button"
         href="{{ search_state.full_ask_url(group_id=group_id) }}"
-        >{% if group %}
+        >{% if settings.ASK_BUTTON_TEXT %}
+            {{ settings.ASK_BUTTON_TEXT }}
+        {% elif group %}
             {{ settings.WORDS_ASK_THE_GROUP|escape }}
         {% else %}
             {{ settings.WORDS_ASK_YOUR_QUESTION|escape }}


### PR DESCRIPTION
Created new askbot setting ASK_BUTTON_TEXT, and use it if it's defined, otherwise set the button text as we did before.

Trello ticket [New askbot setting: custom text for big ask button](https://trello.com/c/Nr2Vj5XY/669-new-askbot-setting-custom-text-for-big-ask-button-see-depl-notes).