### PR TITLE
Form Errors should not delete the label completely

### DIFF
--- a/askbot/media/js/post.js
+++ b/askbot/media/js/post.js
@@ -657,7 +657,7 @@ CommentVoteButton.prototype.createDom = function () {
  */
 var updateQuestionFollowerCount = function (evt, data) {
     var fav = $('.js-question-follower-count');
-    var count = data['num_followers'];
+    var count = data.num_followers;
     if (count === 0) {
         fav.text('');
     } else {

--- a/askbot/media/js/post.js
+++ b/askbot/media/js/post.js
@@ -58,6 +58,12 @@ function setupFormValidation(form, validationRules, validationMessages, onSubmit
         messages: (validationMessages ? validationMessages : {}),
         errorElement: 'span',
         errorClass: 'form-error',
+        highlight: function (element) {
+            $(element).parent('.form-group').addClass('has-error');
+        },
+        unhighlight: function (element) {
+            $(element).parent('.form-group').removeClass('has-error');
+        },
         errorPlacement: function (error, element) {
             var span = element.next().find('span.form-error');
             if (span.length === 0) {
@@ -65,10 +71,11 @@ function setupFormValidation(form, validationRules, validationMessages, onSubmit
                 if (span.length === 0) {
                     //for resizable textarea
                     var element_id = element.attr('id');
-                    span = $('label[for="' + element_id + '"]');
+                    $('label[for="' + element_id + '"]').after(error);
                 }
+            } else {
+                span.replaceWith(error);
             }
-            span.replaceWith(error);
         },
         submitHandler: function (form_dom) {
             disableSubmitButton($(form_dom));

--- a/askbot/media/js/utils.js
+++ b/askbot/media/js/utils.js
@@ -44,8 +44,8 @@ var copyAltToTitle = function (sel) {
  * @returns jQuery with same content and classes,
  * but different tag name (DOM node name)
  */
-var setHtmlTag = function(fromElement, toTagName) {
-    if (fromElement.attr('tagName') == toTagName.toUpperCase()) {
+var setHtmlTag = function (fromElement, toTagName) {
+    if (fromElement.attr('tagName') === toTagName.toUpperCase()) {
         return fromElement;
     }
     var newElement = $('<' + toTagName + '></' + toTagName + '>');

--- a/askbot/media/js/utils/autocompleter.js
+++ b/askbot/media/js/utils/autocompleter.js
@@ -4,7 +4,7 @@
  * @param {Object=} options Settings
  * @constructor
  */
-var AutoCompleter = function(options) {
+var AutoCompleter = function (options) {
 
     /**
      * Default options for autocomplete plugin
@@ -129,13 +129,13 @@ var AutoCompleter = function(options) {
         this.options.maxCacheLength = 10;
     }
 
-    if (this.options['preloadData'] === true){
-        this.fetchRemoteData('', function(){});
+    if (this.options.preloadData === true) {
+        this.fetchRemoteData('', function () {});
     }
 };
 inherits(AutoCompleter, WrappedElement);
 
-AutoCompleter.prototype.decorate = function(element){
+AutoCompleter.prototype.decorate = function (element) {
 
     /**
      * Init DOM elements repository
@@ -167,22 +167,22 @@ AutoCompleter.prototype.decorate = function(element){
     this.setEventHandlers();
 };
 
-AutoCompleter.prototype.setPrompt = function() {
-    this._element.val(this.options['promptText']);
+AutoCompleter.prototype.setPrompt = function () {
+    this._element.val(this.options.promptText);
     this._element.addClass('prompt');
 };
 
-AutoCompleter.prototype.removePrompt = function() {
+AutoCompleter.prototype.removePrompt = function () {
     if (this._element.hasClass('prompt')) {
         this._element.removeClass('prompt');
         var val = this._element.val();
-        if (val === this.options['promptText']) {
+        if (val === this.options.promptText) {
             this._element.val('');
         }
     }
 };
 
-AutoCompleter.prototype.setEventHandlers = function(){
+AutoCompleter.prototype.setEventHandlers = function () {
     /**
      * Shortcut to self
      */
@@ -191,7 +191,7 @@ AutoCompleter.prototype.setEventHandlers = function(){
     /**
      * Attach keyboard monitoring to $elem
      */
-    self._element.keydown(function(e) {
+    self._element.keydown(function (e) {
 
         self.removePrompt();
 
@@ -206,7 +206,6 @@ AutoCompleter.prototype.setEventHandlers = function(){
                     self.activate();
                 }
                 return false;
-            break;
 
             case 40: // down
                 e.preventDefault();
@@ -216,7 +215,6 @@ AutoCompleter.prototype.setEventHandlers = function(){
                     self.activate();
                 }
                 return false;
-            break;
 
             case 9: // tab
             case 13: // return
@@ -244,14 +242,14 @@ AutoCompleter.prototype.setEventHandlers = function(){
 
         }
     });
-    self._element.blur(function() {
+    self._element.blur(function () {
         if (self.finishOnBlur_) {
-            setTimeout(function() { self.finish(); }, 200);
+            setTimeout(function () { self.finish(); }, 200);
         }
     });
 };
 
-AutoCompleter.prototype.position = function() {
+AutoCompleter.prototype.position = function () {
     var offset = this._element.offset();
     this._results.css({
         top: offset.top + this._element.outerHeight(),
@@ -259,7 +257,7 @@ AutoCompleter.prototype.position = function() {
     });
 };
 
-AutoCompleter.prototype.cacheRead = function(filter) {
+AutoCompleter.prototype.cacheRead = function (filter) {
     var filterLength, searchLength, search, maxPos, pos;
     if (this.options.useCache) {
         filter = String(filter);
@@ -289,7 +287,7 @@ AutoCompleter.prototype.cacheRead = function(filter) {
     return false;
 };
 
-AutoCompleter.prototype.cacheWrite = function(filter, data) {
+AutoCompleter.prototype.cacheWrite = function (filter, data) {
     if (this.options.useCache) {
         if (this.cacheLength_ >= this.options.maxCacheLength) {
             this.cacheFlush();
@@ -303,12 +301,12 @@ AutoCompleter.prototype.cacheWrite = function(filter, data) {
     return false;
 };
 
-AutoCompleter.prototype.cacheFlush = function() {
+AutoCompleter.prototype.cacheFlush = function () {
     this.cacheData_ = {};
     this.cacheLength_ = 0;
 };
 
-AutoCompleter.prototype.callHook = function(hook, data) {
+AutoCompleter.prototype.callHook = function (hook, data) {
     var f = this.options[hook];
     if (f && $.isFunction(f)) {
         return f(data, this);
@@ -316,9 +314,9 @@ AutoCompleter.prototype.callHook = function(hook, data) {
     return false;
 };
 
-AutoCompleter.prototype.activate = function() {
+AutoCompleter.prototype.activate = function () {
     var self = this;
-    var activateNow = function() {
+    var activateNow = function () {
         self.activateNow();
     };
     var delay = parseInt(this.options.delay, 10);
@@ -331,7 +329,7 @@ AutoCompleter.prototype.activate = function() {
     this.keyTimeout_ = setTimeout(activateNow, delay);
 };
 
-AutoCompleter.prototype.activateNow = function() {
+AutoCompleter.prototype.activateNow = function () {
     var value = this.getValue();
     if (value !== this.lastProcessedValue_ && value !== this.lastSelectedValue_) {
         if (value.length >= this.options.minChars) {
@@ -342,34 +340,34 @@ AutoCompleter.prototype.activateNow = function() {
     }
 };
 
-AutoCompleter.prototype.fetchData = function(value) {
+AutoCompleter.prototype.fetchData = function (value) {
     if (this.options.data) {
         this.filterAndShowResults(this.options.data, value);
     } else {
         var self = this;
-        this.fetchRemoteData(value, function(remoteData) {
+        this.fetchRemoteData(value, function (remoteData) {
             self.filterAndShowResults(remoteData, value);
         });
     }
 };
 
-AutoCompleter.prototype.fetchRemoteData = function(filter, callback) {
+AutoCompleter.prototype.fetchRemoteData = function (filter, callback) {
     var data = this.cacheRead(filter);
     if (data) {
         callback(data);
     } else {
         var self = this;
-        if (this._element){
+        if (this._element) {
             this._element.addClass(this.options.loadingClass);
         }
-        var ajaxCallback = function(data) {
+        var ajaxCallback = function (data) {
             var parsed = false;
             if (data !== false) {
                 parsed = self.parseRemoteData(data);
                 self.options.data = parsed;//cache data forever - E.F.
                 self.cacheWrite(filter, parsed);
             }
-            if (self._element){
+            if (self._element) {
                 self._element.removeClass(self.options.loadingClass);
             }
             callback(parsed);
@@ -377,18 +375,18 @@ AutoCompleter.prototype.fetchRemoteData = function(filter, callback) {
         $.ajax({
             url: this.makeUrl(filter),
             success: ajaxCallback,
-            error: function() {
+            error: function () {
                 ajaxCallback(false);
             }
         });
     }
 };
 
-AutoCompleter.prototype.setOption = function(name, value){
+AutoCompleter.prototype.setOption = function (name, value) {
     this.options[name] = value;
 };
 
-AutoCompleter.prototype.setExtraParam = function(name, value) {
+AutoCompleter.prototype.setExtraParam = function (name, value) {
     var index = $.trim(String(name));
     if (index) {
         if (!this.options.extraParams) {
@@ -401,7 +399,7 @@ AutoCompleter.prototype.setExtraParam = function(name, value) {
     }
 };
 
-AutoCompleter.prototype.makeUrl = function(param) {
+AutoCompleter.prototype.makeUrl = function (param) {
     var self = this;
     var url = this.options.url;
     var params = $.extend({}, this.options.extraParams);
@@ -418,29 +416,29 @@ AutoCompleter.prototype.makeUrl = function(param) {
     }
 
     var urlAppend = [];
-    $.each(params, function(index, value) {
+    $.each(params, function (index, value) {
         urlAppend.push(self.makeUrlParam(index, value));
     });
     if (urlAppend.length) {
-        url += url.indexOf('?') == -1 ? '?' : '&';
+        url += url.indexOf('?') === -1 ? '?' : '&';
         url += urlAppend.join('&');
     }
     return url;
 };
 
-AutoCompleter.prototype.makeUrlParam = function(name, value) {
+AutoCompleter.prototype.makeUrlParam = function (name, value) {
     return String(name) + '=' + encodeURIComponent(value);
 };
 
 /**
  * Sanitize CR and LF, then split into lines
  */
-AutoCompleter.prototype.splitText = function(text) {
+AutoCompleter.prototype.splitText = function (text) {
     return String(text).replace(/(\r\n|\r|\n)/g, '\n').split(this.options.lineSeparator);
 };
 
-AutoCompleter.prototype.parseRemoteData = function(remoteData) {
-    var value, lines, i, j, data;
+AutoCompleter.prototype.parseRemoteData = function (remoteData) {
+    var value, i, j, data;
     var results = [];
     var lines = this.splitText(remoteData);
     for (i = 0; i < lines.length; i++) {
@@ -455,11 +453,11 @@ AutoCompleter.prototype.parseRemoteData = function(remoteData) {
     return results;
 };
 
-AutoCompleter.prototype.filterAndShowResults = function(results, filter) {
+AutoCompleter.prototype.filterAndShowResults = function (results, filter) {
     this.showResults(this.filterResults(results, filter), filter);
 };
 
-AutoCompleter.prototype.filterResults = function(results, filter) {
+AutoCompleter.prototype.filterResults = function (results, filter) {
 
     var filtered = [];
     var value, data, i, result, type, include;
@@ -517,21 +515,21 @@ AutoCompleter.prototype.filterResults = function(results, filter) {
 
 };
 
-AutoCompleter.prototype.sortResults = function(results, filter) {
+AutoCompleter.prototype.sortResults = function (results, filter) {
     var self = this;
     var sortFunction = this.options.sortFunction;
     if (!$.isFunction(sortFunction)) {
-        sortFunction = function(a, b, f) {
+        sortFunction = function (a, b, f) {
             return self.sortValueAlpha(a, b, f);
         };
     }
-    results.sort(function(a, b) {
+    results.sort(function (a, b) {
         return sortFunction(a, b, filter);
     });
     return results;
 };
 
-AutoCompleter.prototype.sortValueAlpha = function(a, b, filter) {
+AutoCompleter.prototype.sortValueAlpha = function (a, b, filter) {
     a = String(a.value);
     b = String(b.value);
     if (!this.options.matchCase) {
@@ -547,7 +545,7 @@ AutoCompleter.prototype.sortValueAlpha = function(a, b, filter) {
     return 0;
 };
 
-AutoCompleter.prototype.showResults = function(results, filter) {
+AutoCompleter.prototype.showResults = function (results, filter) {
     var self = this;
     var $ul = $('<ul></ul>');
     var i, result, $li, extraWidth, first = false, $first = false;
@@ -557,12 +555,12 @@ AutoCompleter.prototype.showResults = function(results, filter) {
         $li = $('<li>' + this.showResult(result.value, result.data) + '</li>');
         $li.data('value', result.value);
         $li.data('data', result.data);
-        $li.click(function() {
+        $li.click(function () {
             var $this = $(this);
             self.selectItem($this);
-        }).mousedown(function() {
+        }).mousedown(function () {
             self.finishOnBlur_ = false;
-        }).mouseup(function() {
+        }).mouseup(function () {
             self.finishOnBlur_ = true;
         });
         $ul.append($li);
@@ -571,7 +569,7 @@ AutoCompleter.prototype.showResults = function(results, filter) {
             $first = $li;
             $li.addClass(this.options.firstItemClass);
         }
-        if (i == numResults - 1) {
+        if (i === numResults - 1) {
             $li.addClass(this.options.lastItemClass);
         }
     }
@@ -584,15 +582,15 @@ AutoCompleter.prototype.showResults = function(results, filter) {
     extraWidth = this._results.outerWidth() - this._results.width();
     this._results.width(this._element.outerWidth() - extraWidth);
     $('li', this._results).hover(
-        function() { self.focusItem(this); },
-        function() { /* void */ }
+        function () { self.focusItem(this); },
+        function () { /* void */ }
     );
     if (this.autoFill(first, filter)) {
         this.focusItem($first);
     }
 };
 
-AutoCompleter.prototype.showResult = function(value, data) {
+AutoCompleter.prototype.showResult = function (value, data) {
     if ($.isFunction(this.options.showResult)) {
         return this.options.showResult(value, data);
     } else {
@@ -600,9 +598,9 @@ AutoCompleter.prototype.showResult = function(value, data) {
     }
 };
 
-AutoCompleter.prototype.autoFill = function(value, filter) {
+AutoCompleter.prototype.autoFill = function (value, filter) {
     var lcValue, lcFilter, valueLength, filterLength;
-    if (this.options.autoFill && this.lastKeyPressed_ != 8) {
+    if (this.options.autoFill && this.lastKeyPressed_ !== 8) {
         lcValue = String(value).toLowerCase();
         lcFilter = String(filter).toLowerCase();
         valueLength = value.length;
@@ -616,16 +614,16 @@ AutoCompleter.prototype.autoFill = function(value, filter) {
     return false;
 };
 
-AutoCompleter.prototype.focusNext = function() {
+AutoCompleter.prototype.focusNext = function () {
     this.focusMove(+1);
 };
 
-AutoCompleter.prototype.focusPrev = function() {
+AutoCompleter.prototype.focusPrev = function () {
     this.focusMove(-1);
 };
 
-AutoCompleter.prototype.focusMove = function(modifier) {
-    var i, $items = $('li', this._results);
+AutoCompleter.prototype.focusMove = function (modifier) {
+    var $items = $('li', this._results);
     modifier = parseInt(modifier, 10);
     for (var i = 0; i < $items.length; i++) {
         if ($($items[i]).hasClass(this.selectClass_)) {
@@ -636,7 +634,7 @@ AutoCompleter.prototype.focusMove = function(modifier) {
     this.focusItem(0);
 };
 
-AutoCompleter.prototype.focusItem = function(item) {
+AutoCompleter.prototype.focusItem = function (item) {
     var $item, $items = $('li', this._results);
     if ($items.length) {
         $items.removeClass(this.selectClass_).removeClass(this.options.selectClass);
@@ -657,16 +655,16 @@ AutoCompleter.prototype.focusItem = function(item) {
     }
 };
 
-AutoCompleter.prototype.selectCurrent = function() {
+AutoCompleter.prototype.selectCurrent = function () {
     var $item = $('li.' + this.selectClass_, this._results);
-    if ($item.length == 1) {
+    if ($item.length === 1) {
         this.selectItem($item);
     } else {
         this.finish();
     }
 };
 
-AutoCompleter.prototype.selectItem = function($li) {
+AutoCompleter.prototype.selectItem = function ($li) {
     var value = $li.data('value');
     var data = $li.data('data');
     var displayValue = this.displayValue(value, data);
@@ -685,10 +683,10 @@ AutoCompleter.prototype.selectItem = function($li) {
  *                   considered content and false otherwise
  * @param {string} symbol - a single char string
  */
-AutoCompleter.prototype.isContentChar = function(symbol){
-    if (symbol.match(this.options['stopCharRegex'])){
+AutoCompleter.prototype.isContentChar = function (symbol) {
+    if (symbol.match(this.options.stopCharRegex)) {
         return false;
-    } else if (symbol === this.options['multipleSeparator']){
+    } else if (symbol === this.options.multipleSeparator) {
         return false;
     } else {
         return true;
@@ -703,30 +701,30 @@ AutoCompleter.prototype.isContentChar = function(symbol){
  * @return {string} the current word in the
  * autocompletable word
  */
-AutoCompleter.prototype.getValue = function(){
+AutoCompleter.prototype.getValue = function () {
     var sel = this._element.getSelection();
     var text = this._element.val();
     var pos = sel.start;//estimated start
     //find real start
     var start = pos;
-    for (cpos = pos; cpos >= 0; cpos = cpos - 1){
-        if (cpos === text.length){
+    for (cpos = pos; cpos >= 0; cpos = cpos - 1) {
+        if (cpos === text.length) {
             continue;
         }
-        var symbol = text.charAt(cpos);
-        if (!this.isContentChar(symbol)){
+        var symbol_start = text.charAt(cpos);
+        if (!this.isContentChar(symbol_start)) {
             break;
         }
         start = cpos;
     }
     //find real end
     var end = pos;
-    for (cpos = pos; cpos < text.length; cpos = cpos + 1){
-        if (cpos === 0){
+    for (cpos = pos; cpos < text.length; cpos = cpos + 1) {
+        if (cpos === 0) {
             continue;
         }
-        var symbol = text.charAt(cpos);
-        if (!this.isContentChar(symbol)){
+        var symbol_end = text.charAt(cpos);
+        if (!this.isContentChar(symbol_end)) {
             break;
         }
         end = cpos;
@@ -734,20 +732,20 @@ AutoCompleter.prototype.getValue = function(){
     this._selection_start = start;
     this._selection_end = end;
     return text.substring(start, end);
-}
+};
 
 /**
  * sets value of the input box
  * by replacing the previous selection
  * with the value from the autocompleter
  */
-AutoCompleter.prototype.setValue = function(val){
+AutoCompleter.prototype.setValue = function (val) {
     var prefix = this._element.val().substring(0, this._selection_start);
     var postfix = this._element.val().substring(this._selection_end + 1);
     this._element.val(prefix + val + postfix);
 };
 
-AutoCompleter.prototype.displayValue = function(value, data) {
+AutoCompleter.prototype.displayValue = function (value, data) {
     if ($.isFunction(this.options.displayValue)) {
         return this.options.displayValue(value, data);
     } else {
@@ -755,7 +753,7 @@ AutoCompleter.prototype.displayValue = function(value, data) {
     }
 };
 
-AutoCompleter.prototype.finish = function() {
+AutoCompleter.prototype.finish = function () {
     if (this.keyTimeout_) {
         clearTimeout(this.keyTimeout_);
     }
@@ -774,7 +772,7 @@ AutoCompleter.prototype.finish = function() {
     this.active_ = false;
 };
 
-AutoCompleter.prototype.selectRange = function(start, end) {
+AutoCompleter.prototype.selectRange = function (start, end) {
     var input = this._element.get(0);
     if (input.setSelectionRange) {
         input.focus();
@@ -788,7 +786,7 @@ AutoCompleter.prototype.selectRange = function(start, end) {
     }
 };
 
-AutoCompleter.prototype.setCaret = function(pos) {
+AutoCompleter.prototype.setCaret = function (pos) {
     this.selectRange(pos, pos);
 };
 

--- a/askbot/media/js/utils/autocompleter.js
+++ b/askbot/media/js/utils/autocompleter.js
@@ -196,7 +196,7 @@ AutoCompleter.prototype.setEventHandlers = function () {
         self.removePrompt();
 
         self.lastKeyPressed_ = e.keyCode;
-        switch(self.lastKeyPressed_) {
+        switch (self.lastKeyPressed_) {
 
             case 38: // up
                 e.preventDefault();
@@ -223,7 +223,7 @@ AutoCompleter.prototype.setEventHandlers = function () {
                     self.selectCurrent();
                     return false;
                 }
-            break;
+                break;
 
             case 27: // escape
                 if ($.trim(self._element.val()) === '') {
@@ -235,7 +235,7 @@ AutoCompleter.prototype.setEventHandlers = function () {
                     self.finish();
                     return false;
                 }
-            break;
+                break;
 
             default:
                 self.activate();
@@ -296,7 +296,8 @@ AutoCompleter.prototype.cacheWrite = function (filter, data) {
         if (this.cacheData_[filter] !== undefined) {
             this.cacheLength_++;
         }
-        return this.cacheData_[filter] = data;
+        this.cacheData_[filter] = data;
+        return this.cacheData_[filter];
     }
     return false;
 };
@@ -555,14 +556,6 @@ AutoCompleter.prototype.showResults = function (results, filter) {
         $li = $('<li>' + this.showResult(result.value, result.data) + '</li>');
         $li.data('value', result.value);
         $li.data('data', result.data);
-        $li.click(function () {
-            var $this = $(this);
-            self.selectItem($this);
-        }).mousedown(function () {
-            self.finishOnBlur_ = false;
-        }).mouseup(function () {
-            self.finishOnBlur_ = true;
-        });
         $ul.append($li);
         if (first === false) {
             first = String(result.value);
@@ -573,6 +566,15 @@ AutoCompleter.prototype.showResults = function (results, filter) {
             $li.addClass(this.options.lastItemClass);
         }
     }
+
+    $ul.children('li').click(function () {
+        var $this = $(this);
+        self.selectItem($this);
+    }).mousedown(function () {
+        self.finishOnBlur_ = false;
+    }).mouseup(function () {
+        self.finishOnBlur_ = true;
+    });
 
     // Alway recalculate position before showing since window size or
     // input element location may have changed. This fixes #14

--- a/askbot/media/js/utils/two_state_toggle.js
+++ b/askbot/media/js/utils/two_state_toggle.js
@@ -53,7 +53,7 @@ TwoStateToggle.prototype.getDefaultHandler = function () {
         /* @todo: need ability to prevent the ajax call
          * and do something else in certain conditions.
          * For example - invite an unauthenticated user to log in.
-         * This functionality can be better 
+         * This functionality can be better
          * defined in the "SimpleControl".
          */
         $.ajax({
@@ -127,7 +127,7 @@ TwoStateToggle.prototype.decorate = function (element) {
 
     //detect state and save it
     if (this.isCheckBox()) {
-        this._state = element.is(':checked') ? 'on-state': 'off-state';
+        this._state = element.is(':checked') ? 'on-state' : 'off-state';
     } else {
         this._state = element.data('isOn') ? 'on-state' : 'off-state';
     }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,15 +30,7 @@ var ignore = {
         'bower_components/**/*.js',
         'node_modules/**/*.js',
         paths.js + '*.min.js',
-        paths.js + '**/*.min.js',
-        paths.js + 'libs/*.js',
-        paths.js + 'plugins/*.js',
-        paths.js + 'plugins/**/*.js',
-        // these look like they are not used anywhere but we keep em for now
-        paths.js + 'output-words.js',
-        paths.js + 'jquery.form.js',
-        paths.js + 'jquery.ajaxfileupload.js',
-        paths.js + 'jquery.history.js'
+        paths.js + '**/*.min.js'
     ]
 };
 
@@ -63,12 +55,7 @@ gulp.task('compile', function () {
             fileName: 'build.js',
             compilerFlags: {
                 externs: [
-                    // 'askbot/media/js/libs',
-                    // 'askbot/media/js/plugins',
-                    // 'askbot/media/js/output-words.js',
-                    // 'askbot/media/js/jquery.form.js',
-                    // 'askbot/media/js/jquery.ajaxfileupload.js',
-                    // 'askbot/media/js/jquery.history.js'
+                //     'askbot/media/jslib'
                 ],
                 jscomp_off: 'internetExplorerChecks'
             }


### PR DESCRIPTION
Instead of replacing the label with the error, the error gets inserted after the label.
I also added Bootstrap form error class to the from-group, to have bootstrap styling.

Further I fixed all the current javascript validation errors