### PR TITLE
add gulp-closure-compiler to requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
   },
   "engines": {
     "node": ">=0.9.0"
+  },
+  "devDependencies": {
+    "gulp-closure-compiler": "^0.2.14"
   }
 }


### PR DESCRIPTION
To compile the js with closure-compiler we need it as a requirement.

*Note* ClosureCompiler works for all askbot custom javascript, but not with the dependencies.
We can not use the compiled js version yet, because that some jsfiles are throwing errors, when the required dom elements are not found