### PR TITLE
autocomplete on create new message

### DIFF
--- a/askbot/media/js/group_messaging.js
+++ b/askbot/media/js/group_messaging.js
@@ -246,9 +246,9 @@ MessageComposer.prototype.decorate = function (element) {
     var usersAc = new AutoCompleter({
         url: '/get-users-info/',//askbot.urls['get_users_info'],
         minChars: 1,
+        useCache: false,
         matchInside: true,
         maxCacheLength: 100,
-        multipleSeparator: ',',
         delay: 10,
         onItemSelect: userSelectHandler
     });

--- a/askbot/media/js/group_messaging.js
+++ b/askbot/media/js/group_messaging.js
@@ -246,9 +246,9 @@ MessageComposer.prototype.decorate = function (element) {
     var usersAc = new AutoCompleter({
         url: '/get-users-info/',//askbot.urls['get_users_info'],
         minChars: 1,
-        useCache: true,
         matchInside: true,
         maxCacheLength: 100,
+        multipleSeparator: ',',
         delay: 10,
         onItemSelect: userSelectHandler
     });

--- a/askbot/media/js/utils/autocompleter.js
+++ b/askbot/media/js/utils/autocompleter.js
@@ -365,7 +365,10 @@ AutoCompleter.prototype.fetchRemoteData = function (filter, callback) {
             var parsed = false;
             if (data !== false) {
                 parsed = self.parseRemoteData(data);
-                self.options.data = parsed;//cache data forever - E.F.
+                // only cache when cache is enabled
+                if (self.options.useCache) {
+                    self.options.data = parsed;//cache data forever - E.F.
+                }
                 self.cacheWrite(filter, parsed);
             }
             if (self._element) {


### PR DESCRIPTION
The request for the autocomplete on recipients is getting cached.
If I want to add "paulo" and then "diana" to recipients, I can only find paulo.

Only cache the request, if cache is enabled. Do not cache it for group messaging