### PR TITLE
Trigger other events bind to the radio

### DIFF
--- a/askbot/media/js/tag_selector.js
+++ b/askbot/media/js/tag_selector.js
@@ -368,7 +368,7 @@ function pickedTags() {
                     filter_value: clickedBtn.val()
                 },
                 success: function () {
-                    clickedBtn.prop('checked', 'checked');//why?
+                    clickedBtn.prop('checked', true).trigger('change'); // trigger other listeners on the radio
                     askbot.controllers.fullTextSearch.refresh();
                 }
             });


### PR DESCRIPTION
We use uniform.js to style radio button, which is listening to the events of the radio.
But since you unbind click events here: https://github.com/ASKBOT/askbot-devel/blob/master/askbot/media/js/tag_selector.js#L358

Uniform is not getting updated on Internet Explorer and Firefox