### PR TITLE
Use WORDS_ASK_THE_GROUP when 'default_ask_group_id' template variable is set even if 'group' isn't.

### DIFF
--- a/askbot/templates/widgets/ask_button.html
+++ b/askbot/templates/widgets/ask_button.html
@@ -16,7 +16,7 @@
         id="askButton"
         class="button"
         href="{{ search_state.full_ask_url(group_id=group_id) }}"
-        >{% if group %}
+        >{% if group_id %}
             {{ settings.WORDS_ASK_THE_GROUP|escape }}
         {% else %}
             {{ settings.WORDS_ASK_YOUR_QUESTION|escape }}


### PR DESCRIPTION
Merge this commit if you want the button text to be WORDS_ASK_THE_GROUP when variable 'group' is set and/or when variable 'default_ask_group_id' is set, and only fall back to WORDS_ASK_YOUR_QUESTION when neither 'group' nor 'default_ask_group_id' is set.

Currently (without this commit), the button text is WORDS_ASK_THE_GROUP when variable 'group' is set, otherwise the button text is WORDS_ASK_YOUR_QUESTION (even if default_ask_group_id is set).