### PR TITLE
Allow Admin users to access other users inbox

### DIFF
--- a/askbot/conf/access_control.py
+++ b/askbot/conf/access_control.py
@@ -81,7 +81,7 @@ settings.register(
 settings.register(
     livesettings.BooleanValue(
         ACCESS_CONTROL,
-        'ADMIN_USER_ACCESS',
+        'ADMIN_INBOX_ACCESS_ENABLED',
         default=False,
         description=_("Allow moderators to access each other's inbox"),
     )

--- a/askbot/conf/access_control.py
+++ b/askbot/conf/access_control.py
@@ -77,3 +77,12 @@ settings.register(
         help_text=_('Please use space to separate the entries, do not use the @ symbol!')
     )
 )
+
+settings.register(
+    livesettings.BooleanValue(
+        ACCESS_CONTROL,
+        'ADMIN_USER_ACCESS',
+        default=False,
+        description=_("Allow moderators to access each other's inbox"),
+    )
+)

--- a/askbot/deps/group_messaging/views.py
+++ b/askbot/deps/group_messaging/views.py
@@ -34,7 +34,7 @@ class NewThread(PjaxView):
 
     def post(self, request):
         """creates a new thread on behalf of the user
-        response is blank, because on the client side we just 
+        response is blank, because on the client side we just
         need to go back to the thread listing view whose
         content should be cached in the client'
         """
@@ -93,27 +93,28 @@ class PostReply(PjaxView):
 
 
 class ThreadsList(PjaxView):
-    """shows list of threads for a given user"""  
+    """shows list of threads for a given user"""
     template_name = 'group_messaging/threads_list.html'
     http_method_list = ('GET',)
 
-    def get_context(self, request):
+    def get_context(self, request, user):
         """returns thread list data"""
         #get threads and the last visit time
         sender_id = IntegerField().clean(request.REQUEST.get('sender_id', '-1'))
+
         if sender_id == -2:
             threads = Message.objects.get_threads(
-                                            recipient=request.user,
+                                            recipient=user,
                                             deleted=True
                                         )
         elif sender_id == -1:
-            threads = Message.objects.get_threads(recipient=request.user)
-        elif sender_id == request.user.id:
-            threads = Message.objects.get_sent_threads(sender=request.user)
+            threads = Message.objects.get_threads(recipient=user)
+        elif sender_id == user.id:
+            threads = Message.objects.get_sent_threads(sender=user)
         else:
             sender = User.objects.get(id=sender_id)
             threads = Message.objects.get_threads(
-                                            recipient=request.user,
+                                            recipient=user,
                                             sender=sender
                                         )
 
@@ -128,8 +129,8 @@ class ThreadsList(PjaxView):
             thread_data['status'] = 'new'
             #determine the senders info
             senders_names = thread.senders_info.split(',')
-            if request.user.username in senders_names:
-                senders_names.remove(request.user.username)
+            if user.username in senders_names:
+                senders_names.remove(user.username)
             thread_data['senders_info'] = ', '.join(senders_names)
             thread_data['thread'] = thread
             threads_data[thread.id] = thread_data
@@ -146,7 +147,7 @@ class ThreadsList(PjaxView):
             threads_data[thread_id]['responses_count'] = responses_count
 
         last_visit_times = LastVisitTime.objects.filter(
-                                            user=request.user,
+                                            user=user,
                                             message__in=threads
                                         )
         for last_visit in last_visit_times:

--- a/askbot/setup_templates/settings.py
+++ b/askbot/setup_templates/settings.py
@@ -304,7 +304,8 @@ NOTIFICATION_DELAY_TIME = 60 * 15
 
 GROUP_MESSAGING = {
     'BASE_URL_GETTER_FUNCTION': 'askbot.models.user_get_profile_url',
-    'BASE_URL_PARAMS': {'section': 'messages', 'sort': 'inbox'}
+    'BASE_URL_PARAMS': {'section': 'messages', 'sort': 'inbox'},
+    'ADMIN_USER_ACCESS': False
 }
 
 ASKBOT_MULTILINGUAL = False

--- a/askbot/setup_templates/settings.py
+++ b/askbot/setup_templates/settings.py
@@ -304,8 +304,7 @@ NOTIFICATION_DELAY_TIME = 60 * 15
 
 GROUP_MESSAGING = {
     'BASE_URL_GETTER_FUNCTION': 'askbot.models.user_get_profile_url',
-    'BASE_URL_PARAMS': {'section': 'messages', 'sort': 'inbox'},
-    'ADMIN_USER_ACCESS': False
+    'BASE_URL_PARAMS': {'section': 'messages', 'sort': 'inbox'}
 }
 
 ASKBOT_MULTILINGUAL = False

--- a/askbot/views/users.py
+++ b/askbot/views/users.py
@@ -758,7 +758,7 @@ def user_responses(request, user, context):
         return show_group_join_requests(request, user, context)
     elif section == 'messages':
         if request.user != user:
-            if askbot_settings.ADMIN_USER_ACCESS == False:
+            if askbot_settings.ADMIN_INBOX_ACCESS_ENABLED == False:
                 raise Http404
             elif not(request.user.is_moderator() or request.user.is_administrator()):
                 raise Http404

--- a/askbot/views/users.py
+++ b/askbot/views/users.py
@@ -758,7 +758,7 @@ def user_responses(request, user, context):
         return show_group_join_requests(request, user, context)
     elif section == 'messages':
         if request.user != user:
-            if django_settings.GROUP_MESSAGING['ADMIN_USER_ACCESS'] == False:
+            if askbot_settings.ADMIN_USER_ACCESS == False:
                 raise Http404
             elif not(request.user.is_moderator() or request.user.is_administrator()):
                 raise Http404

--- a/askbot/views/users.py
+++ b/askbot/views/users.py
@@ -656,7 +656,7 @@ def user_recent(request, user, context):
     # the return value is dictionary where activity id's are keys
     content_objects_by_activity = activity_objects.fetch_content_objects_dict()
 
-        
+
     #a list of digest objects, suitable for display
     #the number of activities to show is not guaranteed to be
     #const.USER_VIEW_DATA_TYPE, because we don't show activity
@@ -750,18 +750,19 @@ def user_responses(request, user, context):
 
     #1) select activity types according to section
     section = request.GET.get('section', 'forum')
+
     if section == 'forum':
         activity_types = const.RESPONSE_ACTIVITY_TYPES_FOR_DISPLAY
         activity_types += (const.TYPE_ACTIVITY_MENTION,)
     elif section == 'join_requests':
         return show_group_join_requests(request, user, context)
     elif section == 'messages':
-        if request.user != user:
+        if not request.user.is_administrator() and request.user != user:
             raise Http404
 
         from group_messaging.views import SendersList, ThreadsList
         context.update(SendersList().get_context(request))
-        context.update(ThreadsList().get_context(request))
+        context.update(ThreadsList().get_context(request, user))
         data = {
             'inbox_threads_count': context['threads_count'],#a hackfor the inbox count
             'active_tab':'users',

--- a/askbot/views/users.py
+++ b/askbot/views/users.py
@@ -757,8 +757,11 @@ def user_responses(request, user, context):
     elif section == 'join_requests':
         return show_group_join_requests(request, user, context)
     elif section == 'messages':
-        if not request.user.is_administrator() and request.user != user:
-            raise Http404
+        if request.user != user:
+            if django_settings.GROUP_MESSAGING['ADMIN_USER_ACCESS'] == False:
+                raise Http404
+            elif not(request.user.is_moderator() or request.user.is_administrator()):
+                raise Http404
 
         from group_messaging.views import SendersList, ThreadsList
         context.update(SendersList().get_context(request))


### PR DESCRIPTION
We want to give admins access to all users inboxes:

There is now a setting under: /settings/ACCESS_CONTROL/
Default value is false to not backward compatibility.

