### PR TITLE
add back button functionality in inbox

### DIFF
--- a/askbot/media/js/group_messaging.js
+++ b/askbot/media/js/group_messaging.js
@@ -266,7 +266,9 @@ MessageComposer.prototype.decorate = function (element) {
     var me = this;
     var cancelBtn = element.find('.js-cancel-btn');
     this._cancelBtn = cancelBtn;
-    var cancelHandler = function () { me.cancel(); };
+    var cancelHandler = function () {
+        me.cancel();
+    };
     setupButtonEventHandlers(cancelBtn, cancelHandler);
 
     //send button
@@ -482,7 +484,9 @@ SendersList.prototype.getSenderSelectHandler = function (sender) {
     var messageCenter = this._messageCenter;
     var me = this;
     return function () {
-        $.map(me.getSenders(), function (s) { s.unselect(); });
+        $.map(me.getSenders(), function (s) {
+            s.unselect();
+        });
         sender.select();
         messageCenter.loadThreadsForSender(sender.getId());
     };
@@ -520,9 +524,11 @@ MessageCenter.prototype.setState = function (state) {
         this._editor.show();
         this._threadListBox.hide();
         this._threadDetailsBox.hide();
+        this._backBtn.show();
     } else if (state === 'show-list') {
         this._editor.setEditorType('new-thread');
         this._editor.hide();
+        this._backBtn.hide();
         this._threadListBox.show();
         this._threadDetailsBox.hide();
     } else if (state === 'show-thread') {
@@ -530,6 +536,7 @@ MessageCenter.prototype.setState = function (state) {
         this._threadDetailsBox.show();
         this._editor.setEditorType('reply');
         this._editor.show();
+        this._backBtn.show();
     }
 };
 
@@ -695,6 +702,12 @@ MessageCenter.prototype.decorate = function (element) {
         me.setState('compose');
     });
     this._composeBtn = btn;
+
+    var backBtn = element.find('.js-back-btn');
+    setupButtonEventHandlers(backBtn, function () {
+        me.setState('show-list');
+    });
+    this._backBtn = backBtn;
 };
 
 var msgCtr = new MessageCenter();

--- a/askbot/templates/group_messaging/home.html
+++ b/askbot/templates/group_messaging/home.html
@@ -6,6 +6,7 @@
     <tr>
         <td>
             <div class="pm-nav">
+                <button style="display: none" class="submit js-back-btn">{% trans %}back{% endtrans %}</button>
                 <button class="submit compose js-compose-btn">{% trans %}compose{% endtrans %}</button>
                 {% include "group_messaging/senders_list.html" %}
             </div>
@@ -28,13 +29,13 @@
                 {% csrf_token %}
                 <div class="form-group js-to-container">
                     <label for="id_recipients" class="control-label"></label>
-                    <input class="form-control" id="id_recipients" 
+                    <input class="form-control" id="id_recipients"
                         name="recipients" placeholder="{% trans %}Recipient{% endtrans %}"
                         type="text" autocomplete="off">
                 </div>
                 <div class="form-group js-text-container">
                     <label for="id_message_text" class="control-label"></label>
-                    <textarea class="form-control" id="id_message_text" 
+                    <textarea class="form-control" id="id_message_text"
                         placeholder="{% trans %}Write your message{% endtrans %}"
                         rows="10" name="message_text" type=""></textarea>
                 </div>


### PR DESCRIPTION
Currently the only way to go back to threads list is to click on a tab `received/sent/trash`.
This PR adds back button near compose message button that's visible then it's possible to go back.