### PR TITLE
moves followit registration to bottom of models.

### DIFF
--- a/askbot/models/__init__.py
+++ b/askbot/models/__init__.py
@@ -2,12 +2,6 @@ from askbot import startup_procedures
 startup_procedures.run()
 
 from django.contrib.auth.models import User
-#set up a possibility for the users to follow others
-try:
-    import followit
-    followit.register(User)
-except ImportError:
-    pass
 
 import collections
 import datetime
@@ -4070,6 +4064,14 @@ signals.site_visited.connect(
     record_user_visit,
     dispatch_uid='record_user_visit'
 )
+
+#set up a possibility for the users to follow others
+try:
+    import followit
+    followit.register(User)
+except ImportError:
+    pass
+
 
 __all__ = [
         'signals',


### PR DESCRIPTION
without this, when django first loads askbot, it will do this registration which will then call ```get_user_model()``` when using django >= 1.5 , ```get_user_model()``` will then load all django apps again to find the "custom user model" and once done then continue loading the askbot models file.

The scenario above causes many problems, for one it makes askbot's loading order irrelevant because it will always load at the end of all apps regardless of where it is in ```INSTALLED_APPS```, two models that depend on the askbot User model patch will raise ```AttributeErrors``` because askbot's User model has not finished loading since it's the last app.