### PR TITLE
Show the tags for all questions on the homepage

### DIFF
--- a/askbot/views/readers.py
+++ b/askbot/views/readers.py
@@ -111,7 +111,7 @@ def questions(request, **kwargs):
     models.Thread.objects.precache_view_data_hack(threads=page.object_list)
 
     related_tags = Tag.objects.get_related_to_search(
-                        threads=page.object_list,
+                        threads=qs,
                         ignored_tag_names=meta_data.get('ignored_tag_names',[])
                     )
     tag_list_type = askbot_settings.TAG_LIST_FORMAT


### PR DESCRIPTION
...not just the ones for the questions on the current page.