### PR TITLE
Fix vote cancel timeout check and allow disabling it

### DIFF
--- a/askbot/conf/vote_rules.py
+++ b/askbot/conf/vote_rules.py
@@ -48,7 +48,8 @@ settings.register(
         VOTE_RULES,
         'MAX_DAYS_TO_CANCEL_VOTE',
         default=1,
-        description=_('Number of days to allow canceling votes')
+        description=_('Number of days to allow canceling votes '
+            '(-1 for no limit)')
     )
 )
 

--- a/askbot/models/__init__.py
+++ b/askbot/models/__init__.py
@@ -1332,8 +1332,10 @@ def user_assert_can_revoke_old_vote(self, vote):
     """raises exceptions.PermissionDenied if old vote
     cannot be revoked due to age of the vote
     """
-    if (datetime.datetime.now().day - vote.voted_at.day) \
-        >= askbot_settings.MAX_DAYS_TO_CANCEL_VOTE:
+    if askbot_settings.MAX_DAYS_TO_CANCEL_VOTE < 0:
+        return
+    if (datetime.datetime.now() - vote.voted_at).days \
+            >= askbot_settings.MAX_DAYS_TO_CANCEL_VOTE:
         raise django_exceptions.PermissionDenied(
             _('sorry, but older votes cannot be revoked')
         )


### PR DESCRIPTION
Instead of comparing the difference in day of month now and when vote was created, compare the actual time delta in days.

Also added possibility to disable the time limit by setting the MAX_DAYS_TO_CANCEL_VOTE to -1.