### PR TITLE
Lazy translations

### DIFF
--- a/askbot/deps/django_authopenid/forms.py
+++ b/askbot/deps/django_authopenid/forms.py
@@ -349,13 +349,13 @@ class ChangePasswordForm(forms.Form):
     new_password = forms.CharField(
                         widget=forms.PasswordInput(),
                         error_messages = {
-                            'required': _('password is required'),
+                            'required': ugettext_lazy('password is required'),
                         }
                     )
     new_password_retyped = forms.CharField(
                         widget=forms.PasswordInput(),
                         error_messages = {
-                            'required': _('retype your password'),
+                            'required': ugettext_lazy('retype your password'),
                         }
                     )
 

--- a/askbot/utils/decorators.py
+++ b/askbot/utils/decorators.py
@@ -120,10 +120,9 @@ def ajax_only(view_func):
     return wrapper
 
 def check_authorization_to_post(func_or_message):
-
     message = _('Please login to post')
     if not inspect.isfunction(func_or_message):
-        message = unicode(func_or_message)
+        message = func_or_message
 
     def decorator(view_func):
         @functools.wraps(view_func)
@@ -131,7 +130,7 @@ def check_authorization_to_post(func_or_message):
             if request.user.is_anonymous():
                 #todo: expand for handling ajax responses
                 if askbot_settings.ALLOW_POSTING_BEFORE_LOGGING_IN == False:
-                    request.user.message_set.create(message = message)
+                    request.user.message_set.create(message=unicode(message))
                     params = 'next=%s' % request.path
                     return HttpResponseRedirect(url_utils.get_login_url() + '?' + params)
             return view_func(request, *args, **kwargs)

--- a/askbot/utils/forms.py
+++ b/askbot/utils/forms.py
@@ -5,10 +5,9 @@ from django.core.urlresolvers import reverse
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext_lazy as _
-from django.utils.safestring import mark_safe
 from askbot.conf import settings as askbot_settings
 from askbot.utils.slug import slugify
-from askbot.utils.functions import split_list
+from askbot.utils.functions import split_list, mark_safe_lazy
 from askbot import const
 from longerusername import MAX_USERNAME_LENGTH
 import logging

--- a/askbot/utils/forms.py
+++ b/askbot/utils/forms.py
@@ -227,7 +227,7 @@ class UserEmailField(forms.EmailField):
             widget=widget_class(
                     attrs=dict(login_form_widget_attrs, maxlength=200)
                 ),
-            label=mark_safe(_('Your email <i>(never shared)</i>')),
+            label=mark_safe_lazy(_('Your email <i>(never shared)</i>')),
             error_messages={
                 'required':_('email address is required'),
                 'invalid':_('please enter a valid email address'),

--- a/askbot/utils/functions.py
+++ b/askbot/utils/functions.py
@@ -5,6 +5,13 @@ import time
 from django.utils.translation import ugettext as _
 from django.utils.translation import ungettext
 from django.utils.html import escape
+from django.utils import six
+from django.utils.functional import lazy
+from django.utils.safestring import mark_safe
+
+
+mark_safe_lazy = lazy(mark_safe, six.text_type)
+
 
 def timedelta_total_seconds(td):
     """returns total seconds for the timedelta object


### PR DESCRIPTION
Spotted some calls referencing hard strings instead of lazy translations, causing these strings to use the language active when they are first used.