### PR TITLE
Query tags by language

### DIFF
--- a/askbot/models/question.py
+++ b/askbot/models/question.py
@@ -372,7 +372,8 @@ class ThreadManager(BaseQuerySetManager):
                 #only one or two search tags anyway
                 for tag in tags:
                     try:
-                        tag_record = Tag.objects.get(name__iexact=tag)
+                        tag_record = Tag.objects.get(name__iexact=tag,
+                                                     language_code__iexact=get_language())
                         existing_tags.add(tag_record.name)
                     except Tag.DoesNotExist:
                         non_existing_tags.add(tag)


### PR DESCRIPTION
Otherwise, it breaks when multiple languages have the same Tag
because the Get will return multiple results.

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>