### PR TITLE
remove thread when post removed

### DIFF
--- a/askbot/search/haystack/signals.py
+++ b/askbot/search/haystack/signals.py
@@ -11,6 +11,19 @@ class AskbotRealtimeSignalProcessor(RealtimeSignalProcessor):
     modifications to work with askbot soft-delete models
     '''
 
+    def handle_delete(self, sender, instance, **kwargs):
+        # avoid circular imports
+        from askbot.models import Post, Thread
+
+        if isinstance(instance, Post) and instance.thread_id:
+            # instance becomes the thread instance
+            # sender becomes the Thread class
+            # this is because we don't index Post instances, only Thread
+            # but still need to update/remove thread when post is removed.
+            instance, sender = (instance.thread, Thread)
+
+        super(AskbotRealtimeSignalProcessor, self).handle_delete(sender, instance, **kwargs)
+
     def setup(self):
         super(AskbotRealtimeSignalProcessor, self).setup()
 


### PR DESCRIPTION
I only override this on ```handle_delete``` because I'm assuming the thread object gets updated every time a post is updated, contrary to when a post is deleted.

Overriding this on ```handle_save``` could cause the thread object to be indexed multiple times for no reason.