### PR TITLE
Use modern django cache configuration in settings

### DIFF
--- a/askbot/deps/livesettings/models.py
+++ b/askbot/deps/livesettings/models.py
@@ -133,8 +133,10 @@ class Setting(models.Model, CachedObjectMixin):
     def cache_set(self, *args, **kwargs):
         val = kwargs.pop('value', self)
         key = self.cache_key(*args, **kwargs)
-        #TODO: fix this with Django's > 1.3 CACHE dict setting support
-        length = getattr(settings, 'LIVESETTINGS_CACHE_TIMEOUT', settings.CACHE_TIMEOUT)
+        if 'CACHES' in settings:
+            length = getattr(settings, 'LIVESETTINGS_CACHE_TIMEOUT', settings.CACHES['default']['TIMEOUT'])
+        else:
+            length = getattr(settings, 'LIVESETTINGS_CACHE_TIMEOUT', settings.CACHE_TIMEOUT)
         cache_set(key, value=val, length=length)
 
     class Meta:

--- a/askbot/setup_templates/settings.py
+++ b/askbot/setup_templates/settings.py
@@ -197,13 +197,20 @@ INSTALLED_APPS = (
 
 
 #setup memcached for production use!
-#see http://docs.djangoproject.com/en/1.1/topics/cache/ for details
-CACHE_BACKEND = 'locmem://'
-#needed for django-keyedcache
-CACHE_TIMEOUT = 6000
+# See http://docs.djangoproject.com/en/1.8/topics/cache/ for details.
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'askbot',
+        'TIMEOUT': 6000,
+        # Chose a unique KEY_PREFIX to avoid clashes with other applications
+        # using the same cache (e.g. a shared memcache instance).
+        'KEY_PREFIX': 'askbot',
+    }
+}
+
 #sets a special timeout for livesettings if you want to make them different
-LIVESETTINGS_CACHE_TIMEOUT = CACHE_TIMEOUT
-CACHE_KEY_PREFIX = 'askbot' #make this unique
+LIVESETTINGS_CACHE_TIMEOUT = CACHES['default']['TIMEOUT']
 CACHE_MIDDLEWARE_ANONYMOUS_ONLY = True
 #If you use memcache you may want to uncomment the following line to enable memcached based sessions
 #SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'

--- a/askbot/setup_templates/settings.py.mustache
+++ b/askbot/setup_templates/settings.py.mustache
@@ -193,13 +193,20 @@ INSTALLED_APPS = (
 
 
 #setup memcached for production use!
-#see http://docs.djangoproject.com/en/1.1/topics/cache/ for details
-CACHE_BACKEND = 'locmem://'
-#needed for django-keyedcache
-CACHE_TIMEOUT = 6000
+# See http://docs.djangoproject.com/en/1.8/topics/cache/ for details.
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'askbot',
+        'TIMEOUT': 6000,
+        # Chose a unique KEY_PREFIX to avoid clashes with other applications
+        # using the same cache (e.g. a shared memcache instance).
+        'KEY_PREFIX': 'askbot',
+    }
+}
+
 #sets a special timeout for livesettings if you want to make them different
-LIVESETTINGS_CACHE_TIMEOUT = CACHE_TIMEOUT
-CACHE_PREFIX = 'askbot' #make this unique
+LIVESETTINGS_CACHE_TIMEOUT = CACHES['default']['TIMEOUT']
 CACHE_MIDDLEWARE_ANONYMOUS_ONLY = True
 #If you use memcache you may want to uncomment the following line to enable memcached based sessions
 #SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'


### PR DESCRIPTION
Changing `CACHE_BACKEND` to `memcached://127.0.0.1:11211/` has no effect at all anymore with django 1.8.