### PR TITLE
Fixed typo - "Waiting approval" should be "Awaiting approval".

### DIFF
--- a/askbot/templates/macros.html
+++ b/askbot/templates/macros.html
@@ -248,7 +248,7 @@
                     data-on-state-text="{% trans %}You are a member{% endtrans %}"
                 {% else %}
                     data-off-prompt-text="{% trans %}Cancel application{% endtrans %}"
-                    data-on-state-text="{% trans %}Waiting approval{% endtrans %}"
+                    data-on-state-text="{% trans %}Awaiting approval{% endtrans %}"
                 {% endif %}
                 data-on-prompt-text="{% trans %}Ask to join{% endtrans %}"
                 data-off-state-text="{% trans %}Ask to join{% endtrans %}"
@@ -257,7 +257,7 @@
             {% if membership_level == 'full' %}
                 {% trans %}You are a member{% endtrans %}
             {% elif membership_level == 'pending' %}
-                {% trans %}Waiting approval{% endtrans %}
+                {% trans %}Awaiting approval{% endtrans %}
             {% else %}
                 {% if acceptance_level == 'open' %}
                     {% trans %}Join this group{% endtrans %}


### PR DESCRIPTION
Will impact .po translation files, but I'm unable to run makemessages on my instance so I leave that to somebody else. Any non-English translations of msgid "Waiting approval" are likely to still be valid for "Awaiting approval", so probably just a matter of removing the fuzzy markers.