### PR TITLE
Added ('d', _('administrator')) to USER_STATUS_CHOICES (ie the tuple of

### DIFF
--- a/askbot/const/__init__.py
+++ b/askbot/const/__init__.py
@@ -392,6 +392,7 @@ COMMENT_HARD_MAX_LENGTH = 2048
 USER_STATUS_CHOICES = (
         #in addition to these there is administrator
         #admin status is determined by the User.is_superuser() call
+        ('d', _('administrator')),
         ('m', _('moderator')), #user with moderation privilege
         ('a', _('approved')), #regular user
         ('w', _('watched')), #regular user placed on the moderation watch


### PR DESCRIPTION
choices for the status field of class User).

Presumably it used to be in there at some point because there are loads
of pieces of code that behave as if it's a valid value for the
user.status field.

For example:
* askbot/models/__init__.py's user_set_status function checks that the
 supplied new_status is in ('d', 'm', 's', 'b', 'w', 'a'), and its
make_admin_if_first_user function calls user.set_status('d').
* askbot/forms.py's ChangeUserStatusForm is provided with this as one of
the valid choices.
* etc...