### PR TITLE
require coffin < 2.0.0

### DIFF
--- a/askbot_requirements.txt
+++ b/askbot_requirements.txt
@@ -1,4 +1,4 @@
-Coffin>=0.3
+Coffin>=0.3,<2.0.0
 Jinja2
 Lamson
 South>=0.7.1


### PR DESCRIPTION
https://pypi.python.org/pypi/Coffin/2.0.0 was released a day ago (2015-04-17) and breaks askbot installation, the error message is https://gist.github.com/stapelberg/989a8324b0af7dac9894

See also https://github.com/coffin/coffin/issues/88