### PR TITLE
check for input existence, and only then start working with it

### DIFF
--- a/askbot/media/wmd/wmd.js
+++ b/askbot/media/wmd/wmd.js
@@ -1900,6 +1900,9 @@ util.prompt = function(text, defaultInputText, makeLinkMarkdown, dialogType){
 		var loadListener = function(){
 
 			wmd.panels = new wmd.PanelCollection();
+			if (!wmd.panels.input) {
+				return;
+			}
 
 			previewMgr = new wmd.previewManager();
 			var previewRefreshCallback = previewMgr.refresh;
@@ -2110,6 +2113,9 @@ util.prompt = function(text, defaultInputText, makeLinkMarkdown, dialogType){
 		};
 
 		var init = function(){
+			if (!wmd.panels.input) {
+				return;
+			}
 
 			setupEvents(wmd.panels.input, applyTimeout);
 			makePreviewHtml();


### PR DESCRIPTION
otherwise throws error ``Cannot set property onpaste of null`` in chrome and various others.
only happened when editor did not exist on the page (e.g. user not logged in)