### PR TITLE
Improve signals handling for post deletion

### DIFF
--- a/askbot/auth.py
+++ b/askbot/auth.py
@@ -99,6 +99,12 @@ def onFlaggedItem(post, user, timestamp=None):
         #post.deleted_by = Admin
         post.save()
 
+        signals.after_post_removed.send(
+            sender=post.__class__,
+            instance=post,
+            deleted_by=user,
+        )
+
 
 @transaction.commit_on_success
 def onUnFlaggedItem(post, user, timestamp=None):
@@ -180,6 +186,13 @@ def onUnFlaggedItem(post, user, timestamp=None):
 
         post.deleted = False
         post.save()
+
+        signals.after_post_restored.send(
+            sender=post.__class__,
+            instance=post,
+            restored_by=user,
+        )
+
 
 @transaction.commit_on_success
 def onAnswerAccept(answer, user, timestamp=None):

--- a/askbot/models/__init__.py
+++ b/askbot/models/__init__.py
@@ -1783,10 +1783,10 @@ def user_delete_answer(
     answer.thread.invalidate_cached_data()
     logging.debug('updated answer count to %d' % answer.thread.answer_count)
 
-    signals.delete_question_or_answer.send(
+    signals.after_post_removed.send(
         sender = answer.__class__,
         instance = answer,
-        delete_by = self
+        deleted_by = self
     )
     award_badges_signal.send(None,
                 event = 'delete_post',
@@ -1822,10 +1822,10 @@ def user_delete_question(
             tag.used_count = tag.used_count - 1
         tag.save()
 
-    signals.delete_question_or_answer.send(
+    signals.after_post_removed.send(
         sender = question.__class__,
         instance = question,
-        delete_by = self
+        deleted_by = self
     )
     award_badges_signal.send(None,
                 event = 'delete_post',
@@ -1948,6 +1948,11 @@ def user_restore_post(
                     tag.deleted_by = None
                     tag.deleted_at = None
                     tag.save()
+            signals.after_post_restored.send(
+                sender=post.__class__,
+                instance=post,
+                restored_by=self,
+            )
     else:
         raise NotImplementedError()
 
@@ -4182,7 +4187,7 @@ django_signals.post_delete.connect(
 )
 
 #change this to real m2m_changed with Django1.2
-signals.delete_question_or_answer.connect(
+signals.after_post_removed.connect(
     record_delete_question,
     sender=Post,
     dispatch_uid='record_delete_question_on_delete_post'

--- a/askbot/models/__init__.py
+++ b/askbot/models/__init__.py
@@ -1948,11 +1948,11 @@ def user_restore_post(
                     tag.deleted_by = None
                     tag.deleted_at = None
                     tag.save()
-            signals.after_post_restored.send(
-                sender=post.__class__,
-                instance=post,
-                restored_by=self,
-            )
+        signals.after_post_restored.send(
+            sender=post.__class__,
+            instance=post,
+            restored_by=self,
+        )
     else:
         raise NotImplementedError()
 
@@ -3733,7 +3733,7 @@ def record_cancel_vote(instance, **kwargs):
 
 #todo: weird that there is no record delete answer or comment
 #is this even necessary to keep track of?
-def record_delete_question(instance, delete_by, **kwargs):
+def record_delete_question(instance, deleted_by, **kwargs):
     """
     when user deleted the question
     """
@@ -3745,7 +3745,7 @@ def record_delete_question(instance, delete_by, **kwargs):
         return
 
     activity = Activity(
-                    user=delete_by,
+                    user=deleted_by,
                     active_at=datetime.datetime.now(),
                     content_object=instance,
                     activity_type=activity_type,

--- a/askbot/search/haystack/signals.py
+++ b/askbot/search/haystack/signals.py
@@ -28,7 +28,7 @@ class AskbotRealtimeSignalProcessor(RealtimeSignalProcessor):
         super(AskbotRealtimeSignalProcessor, self).setup()
 
         try:
-            askbot_signals.delete_question_or_answer.connect(self.handle_delete)
+            askbot_signals.after_post_removed.connect(self.handle_delete)
         except ImportError:
             pass
 
@@ -36,7 +36,7 @@ class AskbotRealtimeSignalProcessor(RealtimeSignalProcessor):
         super(AskbotRealtimeSignalProcessor, self).setup()
         #askbot signals
         try:
-            askbot_signals.delete_question_or_answer.disconnect(self.handle_delete)
+            askbot_signals.after_post_removed.disconnect(self.handle_delete)
         except ImportError:
             pass
 
@@ -51,7 +51,7 @@ try:
             django_signals.post_save.connect(self.enqueue_save)
             django_signals.post_delete.connect(self.enqueue_delete)
             try:
-                askbot_signals.delete_question_or_answer.connect(self.enqueue_delete)
+                askbot_signals.after_post_removed.connect(self.enqueue_delete)
             except ImportError:
                 pass
 
@@ -61,7 +61,7 @@ try:
             django_signals.post_delete.disconnect(self.enqueue_delete)
 
             try:
-                askbot_signals.delete_question_or_answer.disconnect(self.enqueue_delete)
+                askbot_signals.after_post_removed.disconnect(self.enqueue_delete)
             except ImportError:
                 pass
 

--- a/askbot/signals.py
+++ b/askbot/signals.py
@@ -23,9 +23,10 @@ tags_updated = django.dispatch.Signal(
                         providing_args=['tags', 'user', 'timestamp']
                     )
 
-delete_question_or_answer = django.dispatch.Signal(
-                                    providing_args=['instance', 'deleted_by']
-                                )
+after_post_removed = django.dispatch.Signal(
+    providing_args=['instance', 'deleted_by'])
+after_post_restored = django.dispatch.Signal(
+    providing_args=['instance', 'restored_by'])
 flag_offensive = django.dispatch.Signal(providing_args=['instance', 'mark_by'])
 remove_flag_offensive = django.dispatch.Signal(providing_args=['instance', 'mark_by'])
 user_updated = django.dispatch.Signal(providing_args=['instance', 'updated_by'])
@@ -101,7 +102,8 @@ def pop_all_db_signal_receivers():
     signals = (
         #askbot signals
         tags_updated,
-        delete_question_or_answer,
+        after_post_removed,
+        after_post_restored,
         flag_offensive,
         remove_flag_offensive,
         user_updated,


### PR DESCRIPTION
* Rename ``delete_question_or_answer`` to ``after_post_removed``
* Correct the ``delete_by`` argument (right name is ``deleted_by``)
* Add ``after_post_restored`` to handle post restoration
* Fire signals from ``user_restore_post``
* Fire signals from ``onFlaggedItem`` and ``onUnflaggedItem``