### PR TITLE
Simplification and handle gmail alias email addresses.

### DIFF
--- a/askbot/utils/forms.py
+++ b/askbot/utils/forms.py
@@ -185,17 +185,14 @@ def email_is_allowed(
     domain"""
     if allowed_emails:
         email_list = split_list(allowed_emails)
-        allowed_emails = ' ' + ' '.join(email_list) + ' '
-        email_match_re = re.compile(r'\s%s\s' % email, re.I)
-        if email_match_re.search(allowed_emails):
+        if email in email_list:
             return True
 
     if allowed_email_domains:
         email_domain = email.split('@')[1]
         domain_list = split_list(allowed_email_domains)
-        domain_match_re = re.compile(r'\s%s\s' % email_domain, re.I)
-        allowed_email_domains = ' ' + ' '.join(domain_list) + ' '
-        return bool(domain_match_re.search(allowed_email_domains))
+        if email_domain in domain_list:
+            return True
 
     return False
 


### PR DESCRIPTION
Fixed this so that it works for emails like 'username+somealias@gmail.com' which contain special regex characters (+ in this case) - don't see why the over-complicated regex is required anyway.