### PR TITLE
Better django admin list view for Avatar model

### DIFF
--- a/askbot/admin.py
+++ b/askbot/admin.py
@@ -348,16 +348,20 @@ finally:
             return ', '.join(obj.get_marked_tags('subscribed').values_list('name', flat=True))
     admin.site.register(User, UserAdmin)
 
-from avatar.models import Avatar
-from django.contrib.admin.sites import NotRegistered
 try:
-    admin.site.unregister(Avatar)
-except NotRegistered:
-    print u"Move 'avatar' above 'askbot' in INSTALLED_APPS to get a more useful admin view for Avatar model" 
+    from avatar.models import Avatar
+except ImportError:
+    pass # avatar not installed, so no matter
 else:
-    class AvatarAdmin(admin.ModelAdmin):
-        list_display = ('id', 'user', 'avatar', 'primary', 'date_uploaded')
-        list_filter = ('primary', 'date_uploaded')
-        search_fields = ('user__username', 'user__email', 'avatar')
-    admin.site.register(Avatar, AvatarAdmin)
+    from django.contrib.admin.sites import NotRegistered
+    try:
+        admin.site.unregister(Avatar)
+    except NotRegistered:
+        print u"Move 'avatar' above 'askbot' in INSTALLED_APPS to get a more useful admin view for Avatar model" 
+    else:
+        class AvatarAdmin(admin.ModelAdmin):
+            list_display = ('id', 'user', 'avatar', 'primary', 'date_uploaded')
+            list_filter = ('primary', 'date_uploaded')
+            search_fields = ('user__username', 'user__email', 'avatar')
+        admin.site.register(Avatar, AvatarAdmin)
 

--- a/askbot/admin.py
+++ b/askbot/admin.py
@@ -347,3 +347,17 @@ finally:
         def my_subscribed_tags(self, obj):
             return ', '.join(obj.get_marked_tags('subscribed').values_list('name', flat=True))
     admin.site.register(User, UserAdmin)
+
+from avatar.models import Avatar
+from django.contrib.admin.sites import NotRegistered
+try:
+    admin.site.unregister(Avatar)
+except NotRegistered:
+    print u"Move 'avatar' above 'askbot' in INSTALLED_APPS to get a more useful admin view for Avatar model" 
+else:
+    class AvatarAdmin(admin.ModelAdmin):
+        list_display = ('id', 'user', 'avatar', 'primary', 'date_uploaded')
+        list_filter = ('primary', 'date_uploaded')
+        search_fields = ('user__username', 'user__email', 'avatar')
+    admin.site.register(Avatar, AvatarAdmin)
+


### PR DESCRIPTION
Will only take effect if you put 'avatar' *before* 'askbot' in INSTALLED_APPS list (we only define and
register it if avatar module's own version has already been registered,
otherwise when that comes to be registered there'll be an
AlreadyRegistered exception). If django_avatar not installed, does nothing.