### PR TITLE
PostManager.get_answers() gets new case user='n/a', and use for Thread.update_last_activity_info()

### DIFF
--- a/askbot/models/post.py
+++ b/askbot/models/post.py
@@ -173,6 +173,8 @@ class PostManager(BaseQuerySetManager):
         optionally filtered to exclude posts of groups
         to which user does not belong"""
         answers = self.filter(post_type='answer')
+        if user == 'n/a':
+            return answers
         return answers.get_for_user(user)
 
     def get_comments(self):

--- a/askbot/models/question.py
+++ b/askbot/models/question.py
@@ -1034,11 +1034,9 @@ class Thread(models.Model):
         self.update_summary_html() # regenerate question/thread summary html
         ####################################################################
 
-    def get_last_activity_info(self):
-        post_ids = self.get_answers().values_list('id', flat=True)
-        question = self._question_post()
-        post_ids = list(post_ids)
-        post_ids.append(question.id)
+    def get_last_activity_info(self, user=None):
+        post_ids = list(self.get_answers(user=user).values_list('id', flat=True))
+        post_ids.append(self._question_post().id)
         from askbot.models import PostRevision
         revs = PostRevision.objects.filter(
                             post__id__in=post_ids,
@@ -1051,7 +1049,9 @@ class Thread(models.Model):
             return None, None
 
     def update_last_activity_info(self):
-        timestamp, user = self.get_last_activity_info()
+        # The Thread can't record this info on a per-user basis so don't 
+        # consider any user memberships when calculating it.
+        timestamp, user = self.get_last_activity_info(user='n/a')
         if timestamp:
             self.set_last_activity_info(timestamp, user)
 


### PR DESCRIPTION
In PostManager's get_answers method, if user='n/a' then don't bother restricting current query set according to anything to do with the
user. Pass a 'n/a' user from Thread's update_last_activity_info - this
should be updated with the absolute truth, not any one user's view of it.