### PR TITLE
Ensure Thread's last_activity_ info is always independent of user

### DIFF
--- a/askbot/models/post.py
+++ b/askbot/models/post.py
@@ -168,12 +168,15 @@ class PostManager(BaseQuerySetManager):
         questions = self.filter(post_type='question')
         return questions.get_for_user(user)
 
-    def get_answers(self, user=None):
+    def get_answers(self, user=None, ignore_user=False):
         """returns query set of answer posts,
         optionally filtered to exclude posts of groups
         to which user does not belong"""
         answers = self.filter(post_type='answer')
-        return answers.get_for_user(user)
+        if ignore_user:
+            return answers
+        else:
+            return answers.get_for_user(user)
 
     def get_comments(self):
         return self.filter(post_type='comment')

--- a/askbot/models/question.py
+++ b/askbot/models/question.py
@@ -1034,8 +1034,8 @@ class Thread(models.Model):
         self.update_summary_html() # regenerate question/thread summary html
         ####################################################################
 
-    def get_last_activity_info(self):
-        post_ids = self.get_answers().values_list('id', flat=True)
+    def get_last_activity_info(self, ignore_user=False):
+        post_ids = self.get_answers(ignore_user=ignore_user).values_list('id', flat=True)
         question = self._question_post()
         post_ids = list(post_ids)
         post_ids.append(question.id)
@@ -1051,7 +1051,7 @@ class Thread(models.Model):
             return None, None
 
     def update_last_activity_info(self):
-        timestamp, user = self.get_last_activity_info()
+        timestamp, user = self.get_last_activity_info(ignore_user=True)
         if timestamp:
             self.set_last_activity_info(timestamp, user)
 
@@ -1132,11 +1132,11 @@ class Thread(models.Model):
     def all_answers(self):
         return self.posts.get_answers()
 
-    def get_answers(self, user=None):
+    def get_answers(self, user=None, ignore_user=False):
         """returns query set for answers to this question
         that may be shown to the given user
         """
-        return self.posts.get_answers(user=user).filter(deleted=False)
+        return self.posts.get_answers(user, ignore_user).filter(deleted=False)
 
     def invalidate_cached_thread_content_fragment(self):
         site_id = django_settings.SITE_ID


### PR DESCRIPTION
Here's an improved version of the fix at https://github.com/ASKBOT/askbot-devel/pull/493:

Ensure that a Thread's last_activity_at and last_activity_by is always independent of any user (a Thread only has one version of these two data items, so we shouldn't be setting them according to any one user's view onto the system).

Previously, Thread.update_last_activity_info() called Thread.get_last_activity_info(), which called Thread.get_answers(), which defaults user to None, and then passes user=None to
PostManager.get_answers(), which assumes that user=None means 'non-logged in user', and hence only returns answers that have been shared with the 'All' Group. For a private question, if an answer is deleted, the Thread's last_activity_ info will be set back to that of the last edit on the question, ignoring any remaining answers, which is wrong.

The fix: Thread.get_last_activity_info(), Thread.get_answers() and PostManager.get_answers() all get new parameter 'ignore_user' which defaults to False (and hence no effect on any existing calls to those methods). PostManager.get_answers() only considers the supplied user if ignore_user=False, else returns all answers regardless of which answers the user can see (which is what we want in this case). Finally, Thread.update_last_activity_info() supplies ignore_user=True when it calls Thread.get_last_activity_info().

Trello ticket: https://trello.com/c/ALfA5KCO/822-use-correct-last-activity-info-when-deleting-answer-for-a-private-question