### PR TITLE
Fix openid provider name lookup

### DIFF
--- a/askbot/deps/django_authopenid/util.py
+++ b/askbot/deps/django_authopenid/util.py
@@ -163,6 +163,23 @@ def get_provider_name(openid_url):
     url_bits = base_url.split('.')
     return url_bits[-2].lower()
 
+def get_provider_name_by_endpoint(openid_url):
+    """returns the provider name by endpoint url
+
+    Pair the openid_url with endpoint urls defined for different openid
+    providers. Returns None if no matching url was found.
+    """
+    parsed_uri = urlparse.urlparse(openid_url)
+    base_url = '{uri.scheme}://{uri.netloc}'.format(uri=parsed_uri)
+    providers = get_enabled_login_providers()
+    for provider_data in providers.itervalues():
+        openid_url_match = (provider_data['type'].startswith('openid') and
+            provider_data['openid_endpoint'] is not None and
+            provider_data['openid_endpoint'].startswith(base_url))
+        if openid_url_match:
+            return provider_data['name']
+    return None
+
 def use_password_login():
     """password login is activated
     if any of the login methods requiring user name

--- a/askbot/deps/django_authopenid/views.py
+++ b/askbot/deps/django_authopenid/views.py
@@ -915,7 +915,9 @@ def signin_success(request, identity_url, openid_response):
                 )
 
     next_url = get_next_url(request)
-    provider_name = util.get_provider_name(openid_url)
+    provider_name = util.get_provider_name_by_endpoint(openid_url)
+    if provider_name is None:
+        provider_name = util.get_provider_name(openid_url)
 
     request.session['email'] = openid_data.sreg.get('email', '')
     request.session['username'] = openid_data.sreg.get('nickname', '')


### PR DESCRIPTION
Previously the provider name lookup of an openid provider during
login process was handled by the get_provider_name() call. This
call just simply extract the domain name from the returned
openid_url, and cannot fully identify different endpoint
settings of an openid provider. For example on our staging
site we are using https://openstackid-dev.openstackid.org,
meanwhile on production site the openid_endpoint url
just simply the https://openstackid.org.

This patch adds the ability to lookup the provider endpoint
settings defined in util.py's get_enabled_major_login_providers().

To provide compatibility with previous implementations, when a
the lookup not results a matching provider name, it fall
back to previous get_provider_name().