### PR TITLE
Fix Thread.update_last_activity_info method

### DIFF
--- a/askbot/models/__init__.py
+++ b/askbot/models/__init__.py
@@ -1655,7 +1655,7 @@ def user_delete_all_content_authored_by_user(self, author, timestamp=None):
     count = 0
 
     #delete answers
-    answers = Post.objects.get_answers().filter(author=author)
+    answers = Post.objects.get_all_answers().filter(author=author)
     timestamp = timestamp or datetime.datetime.now()
     count += answers.update(deleted_at=timestamp, deleted_by=self, deleted=True)
 

--- a/askbot/models/post.py
+++ b/askbot/models/post.py
@@ -168,11 +168,19 @@ class PostManager(BaseQuerySetManager):
         questions = self.filter(post_type='question')
         return questions.get_for_user(user)
 
+    def get_all_answers(self):
+        """
+        Returns 'answer' Posts (regardless of any user). 
+        Use get_answers if you want them filtered by accessibility for an user.
+        """
+        return self.filter(post_type='answer')
+
     def get_answers(self, user=None):
-        """returns query set of answer posts,
-        optionally filtered to exclude posts of groups
-        to which user does not belong"""
-        answers = self.filter(post_type='answer')
+        """
+        Returns only 'answer' Posts, further filtered by accessibility for 
+        given user (where user=None is interpreted as anonymous user).
+        """
+        answers = self.get_all_answers()
         return answers.get_for_user(user)
 
     def get_comments(self):

--- a/askbot/models/question.py
+++ b/askbot/models/question.py
@@ -1035,7 +1035,7 @@ class Thread(models.Model):
         ####################################################################
 
     def get_last_activity_info(self):
-        post_ids = self.get_answers().values_list('id', flat=True)
+        post_ids = self.get_all_answers().exclude(deleted=True).values_list('id', flat=True)
         question = self._question_post()
         post_ids = list(post_ids)
         post_ids.append(question.id)
@@ -1131,12 +1131,24 @@ class Thread(models.Model):
     def tagname_meta_generator(self):
         return u','.join([unicode(tag) for tag in self.get_tag_names()])
 
+    def get_all_answers(self):
+        """
+        All 'answer' Posts (regardless of any user). Calling code is responsible 
+        for further excluding deleted Posts from result if necessary.
+        Method only necessary because get_answers interprets user=None as 
+        anonymous user (not logged in).
+        """
+        return self.posts.get_all_answers()
+
     def all_answers(self):
+        # TODO: check that anything using this method expects to get only 
+        # answers visible to non-logged-in users.
         return self.posts.get_answers()
 
     def get_answers(self, user=None):
-        """returns query set for answers to this question
-        that may be shown to the given user
+        """
+        All non-deleted 'answer' Posts accessible to the specified user, where
+        user=None is interpreted as anonymous user.
         """
         return self.posts.get_answers(user=user).filter(deleted=False)
 


### PR DESCRIPTION
... so that it no longer ignores private 'answer' Posts. Also partly fixes "Block user and delete all content" so that it deletes private as well as public answers (fix for questions to follow).
https://trello.com/c/ALfA5KCO/822-use-correct-last-activity-info-when-deleting-answer-for-a-private-question and https://trello.com/c/EWOVfvrK/879-block-user-and-delete-all-content-doesn-t-delete-private-questions-answers