### PR TITLE
Yaml export

### DIFF
--- a/askbot/deps/livesettings/models.py
+++ b/askbot/deps/livesettings/models.py
@@ -192,4 +192,3 @@ class LongSetting(models.Model, CachedObjectMixin):
 
     class Meta:
         unique_together = ('site', 'group', 'key')
-

--- a/askbot/deps/livesettings/tests.py
+++ b/askbot/deps/livesettings/tests.py
@@ -573,6 +573,10 @@ class ExportTest(TestCase):
 
         request = Mock()
         response = export_as_yaml(request)
+
+        self.assertEqual(response.content,
+                         'REPLY_BY_EMAIL_HOSTNAME: m.knowledgepoint.org\n')
+
         config = yaml.load(response.content)
 
         self.assertEqual(config['REPLY_BY_EMAIL_HOSTNAME'],

--- a/askbot/deps/livesettings/tests.py
+++ b/askbot/deps/livesettings/tests.py
@@ -633,3 +633,30 @@ class DumpYamlTest(UnitTestCase):
         actual = yaml.splitlines()
 
         self.assertEqual(actual, expected)
+
+    def testLanguageSettingsSeparated(self):
+        settings = [
+            {
+                'group': 'QA_SITE_SETTINGS',
+                'key': 'LOGIN_SIGNUP_LINK_TEXT_EN',
+                'value': 'Click here to sign in or register',
+            },
+            {
+                'group': 'QA_SITE_SETTINGS',
+                'key': 'LOGIN_SIGNUP_LINK_TEXT_FR',
+                'value': 'Bonjour, veuillez vous connecter',
+            },
+        ]
+
+        yaml = dump_yaml(settings)
+
+        expected = [
+            '# QA_SITE_SETTINGS',
+            'LOGIN_SIGNUP_LINK_TEXT:',
+            '  en: Click here to sign in or register',
+            '  fr: Bonjour, veuillez vous connecter',
+        ]
+
+        actual = yaml.splitlines()
+
+        self.assertEqual(actual, expected)

--- a/askbot/deps/livesettings/tests.py
+++ b/askbot/deps/livesettings/tests.py
@@ -552,7 +552,7 @@ class OverrideTest(TestCase):
 
 
 class ExportTest(TestCase):
-    def testStringExported(self):
+    def setUp(self):
         GENERAL_SKIN_SETTINGS = ConfigurationGroup(
             'GENERAL_SKIN_SETTINGS',
             'Skins settings'
@@ -564,6 +564,7 @@ class ExportTest(TestCase):
             default='default'
         ))
 
+    def testStringExported(self):
         value = StringValue(
             BASE_GROUP,
             'REPLY_BY_EMAIL_HOSTNAME')
@@ -576,6 +577,22 @@ class ExportTest(TestCase):
 
         self.assertEqual(response.content,
                          'REPLY_BY_EMAIL_HOSTNAME: m.knowledgepoint.org\n')
+
+        config = yaml.load(response.content)
+
+        self.assertEqual(config['REPLY_BY_EMAIL_HOSTNAME'],
+                         'm.knowledgepoint.org')
+
+    def testLongStringExported(self):
+        value = LongStringValue(
+            BASE_GROUP,
+            'REPLY_BY_EMAIL_HOSTNAME')
+
+        setting = value.make_setting('m.knowledgepoint.org')
+        setting.save()
+
+        request = Mock()
+        response = export_as_yaml(request)
 
         config = yaml.load(response.content)
 

--- a/askbot/deps/livesettings/tests.py
+++ b/askbot/deps/livesettings/tests.py
@@ -1,9 +1,15 @@
 from django.conf import settings as djangosettings
 from django.test import TestCase
+from django.utils.unittest.case import TestCase as UnitTestCase
 import keyedcache
 from askbot.deps.livesettings import *
+from askbot.deps.livesettings.views import export_as_yaml
 import logging
+from mock import Mock
+import yaml
+
 log = logging.getLogger('test');
+
 
 class ConfigurationFunctionTest(TestCase):
 
@@ -543,3 +549,31 @@ class OverrideTest(TestCase):
         self.assertEqual(v[0], "one")
         self.assertEqual(v[1], "two")
         self.assertEqual(v[2], "three")
+
+
+class ExportTest(TestCase):
+    def testStringExported(self):
+        GENERAL_SKIN_SETTINGS = ConfigurationGroup(
+            'GENERAL_SKIN_SETTINGS',
+            'Skins settings'
+        )
+
+        config_register(StringValue(
+            GENERAL_SKIN_SETTINGS,
+            'ASKBOT_DEFAULT_SKIN',
+            default='default'
+        ))
+
+        value = StringValue(
+            BASE_GROUP,
+            'REPLY_BY_EMAIL_HOSTNAME')
+
+        setting = value.make_setting('m.knowledgepoint.org')
+        setting.save()
+
+        request = Mock()
+        response = export_as_yaml(request)
+        config = yaml.load(response.content)
+
+        self.assertEqual(config['REPLY_BY_EMAIL_HOSTNAME'],
+                         'm.knowledgepoint.org')

--- a/askbot/deps/livesettings/urls.py
+++ b/askbot/deps/livesettings/urls.py
@@ -5,6 +5,6 @@ except ImportError:
 
 urlpatterns = patterns('askbot.deps.livesettings.views',
     url(r'^$', 'site_settings', {}, name='site_settings'),
-    url(r'^export/$', 'export_as_python', {}, name='settings_export'),
+    url(r'^export/$', 'export_as_yaml', {}, name='settings_export'),
     url(r'^(?P<group>[^/]+)/$', 'group_settings', name='group_settings'),
 )

--- a/askbot/deps/livesettings/views.py
+++ b/askbot/deps/livesettings/views.py
@@ -123,7 +123,7 @@ def export_as_yaml(request):
 def dump_yaml(settings):
     objects = {s['key']: s['value'] for s in settings}
 
-    return yaml.dump(objects)
+    return yaml.dump(objects, default_flow_style=False, Dumper=yaml.SafeDumper)
 
 
 export_as_python = never_cache(staff_member_required(export_as_python))

--- a/askbot/deps/livesettings/views.py
+++ b/askbot/deps/livesettings/views.py
@@ -8,10 +8,12 @@ from askbot.deps.livesettings import ConfigurationSettings, forms
 from askbot.deps.livesettings import ImageValue
 from askbot.deps.livesettings.overrides import get_overrides
 from django.contrib import messages
+
 import logging
 import yaml
 
 log = logging.getLogger('configuration.views')
+
 
 def group_settings(request, group, template='livesettings/group_settings.html'):
     # Determine what set of settings this editor is used for
@@ -105,15 +107,11 @@ def export_as_python(request):
 
 
 def export_as_yaml(request):
-    from askbot.deps.livesettings.models import Setting
+    from askbot.deps.livesettings.models import Setting, LongSetting
 
-    # result = ''
-
-    # for ls in Setting.objects.all().values('group', 'key', 'value'):
-    #    result += u"{0}: \"{1}\"\n".format(ls['key'], ls['value'])
-
-    values = Setting.objects.all().values('group', 'key', 'value')
-    result = dump_yaml(values)
+    settings = list(Setting.objects.all().values('group', 'key', 'value'))
+    long_settings = list(LongSetting.objects.all().values('group', 'key', 'value'))
+    result = dump_yaml(settings + long_settings)
 
     return render_to_response(
         'livesettings/text.txt', {'text': result}, mimetype='text/plain'

--- a/askbot/deps/livesettings/views.py
+++ b/askbot/deps/livesettings/views.py
@@ -9,6 +9,7 @@ from askbot.deps.livesettings import ImageValue
 from askbot.deps.livesettings.overrides import get_overrides
 from django.contrib import messages
 import logging
+import yaml
 
 log = logging.getLogger('configuration.views')
 
@@ -102,4 +103,28 @@ def export_as_python(request):
 
     return render_to_response('livesettings/text.txt', { 'text' : pretty }, mimetype='text/plain')
 
+
+def export_as_yaml(request):
+    from askbot.deps.livesettings.models import Setting
+
+    # result = ''
+
+    # for ls in Setting.objects.all().values('group', 'key', 'value'):
+    #    result += u"{0}: \"{1}\"\n".format(ls['key'], ls['value'])
+
+    values = Setting.objects.all().values('group', 'key', 'value')
+    result = dump_yaml(values)
+
+    return render_to_response(
+        'livesettings/text.txt', {'text': result}, mimetype='text/plain'
+    )
+
+
+def dump_yaml(settings):
+    objects = {s['key']: s['value'] for s in settings}
+
+    return yaml.dump(objects)
+
+
 export_as_python = never_cache(staff_member_required(export_as_python))
+export_as_yaml = never_cache(staff_member_required(export_as_yaml))


### PR DESCRIPTION
https://trello.com/c/lHa8ehJU/735-settings-export-to-be-in-yaml-format

Evgeny, the code that handles the language-specific settings (_create_language_hierarchy) is only applicable to Askbot. Should this go outside of the livesettings code?
