### PR TITLE
Fixed misleading error message when hitting subscribe button

### DIFF
--- a/askbot/views/commands.py
+++ b/askbot/views/commands.py
@@ -1811,4 +1811,4 @@ def toggle_subscribed_site(request):
             is_subscribed = True
         return {'is_enabled': is_subscribed}
     else:
-        raise HttpResponseBadRequest('bad post data')
+        raise exceptions.ValidationError('bad post data')


### PR DESCRIPTION
"exceptions must be old-style classes or derived
from BaseException, not HttpResponseBadRequest"

This was masking another error where the Knowledgepoint template context processor was missing from the settings file  