### PR TITLE
Fix AppRegistryNotReady error we get when running with Apache + Djang…

### DIFF
--- a/askbot/setup_templates/django.wsgi
+++ b/askbot/setup_templates/django.wsgi
@@ -1,5 +1,8 @@
 import os
 import sys
+import time
+import traceback
+import signal
 
 current_directory = os.path.dirname(__file__)
 parent_directory = os.path.dirname(current_directory)
@@ -8,5 +11,15 @@ module_name = os.path.basename(current_directory)
 sys.path.append(parent_directory)
 sys.path.append(current_directory)
 os.environ['DJANGO_SETTINGS_MODULE'] = '%s.settings' % module_name
-import django.core.handlers.wsgi
-application = django.core.handlers.wsgi.WSGIHandler()
+
+from django.core.wsgi import get_wsgi_application
+try:
+    application = get_wsgi_application()
+    print 'WSGI without exception'
+except Exception:
+    print 'handling WSGI exception'
+    # Error loading applications
+    if 'mod_wsgi' in sys.modules:
+        traceback.print_exc()
+        os.kill(os.getpid(), signal.SIGINT)
+        time.sleep(2.5)


### PR DESCRIPTION
…o 1.7. Add exception handling to avoid masking erros by 'populate() isn't reentrant' error. See http://stackoverflow.com/a/30968197/619493 and https://github.com/jezdez/django-constance/issues/77