### PR TITLE
Questions list widget now limits to threads that are visible to the current user

### DIFF
--- a/askbot/views/widgets.py
+++ b/askbot/views/widgets.py
@@ -295,10 +295,12 @@ def question_widget(request, widget_id):
     if widget.search_query:
         filter_params['title__icontains'] = widget.search_query
 
-    if filter_params:
-        threads = models.Thread.objects.filter(**filter_params).order_by(widget.order_by)[:widget.question_number]
-    else:
-        threads = models.Thread.objects.all().order_by(widget.order_by)[:widget.question_number]
+    # Get all Threads that should be visible to the user ...
+    threads = models.Thread.objects.all().get_visible(request.user)
+    # filter by our widget parameters ...
+    threads = threads.filter(**filter_params)
+    # and then order and truncate the set.
+    threads = threads.order_by(widget.order_by)[:widget.question_number]
 
     data = {
              'threads': threads,


### PR DESCRIPTION
https://trello.com/c/s0ebwVHd/9-private-questions-appear-in-question-list-widget-to-anon-users-and-users-who-are-not-in-the-groups