### PR TITLE
Fix openid association expiration issue

### DIFF
--- a/askbot/deps/django_authopenid/util.py
+++ b/askbot/deps/django_authopenid/util.py
@@ -84,7 +84,7 @@ class DjangoOpenIDStore(OpenIDStore):
             handle = association.handle,
             secret = base64.encodestring(association.secret),
             issued = association.issued,
-            lifetime = association.issued,
+            lifetime = association.lifetime,
             assoc_type = association.assoc_type
         )
         assoc.save()


### PR DESCRIPTION
The existing code not handled properly the expiration time of
openid association handle. This caused a sign-in problems with
openstackid.org provider, meanwhile the launchpad provider was
not sensitive for this type of error.

Proper association issue time and lifetime variable assignment in
DjangoOpenIDStore.storeAssociation() function solves this issue
and requests a new association id when the existing one already
expired.