### PR TITLE
Avoid unnecessary whitespace in html markup

### DIFF
--- a/askbot/templates/widgets/ask_button.html
+++ b/askbot/templates/widgets/ask_button.html
@@ -16,9 +16,9 @@
         id="askButton"
         class="button"
         href="{{ search_state.full_ask_url(group_id=group_id) }}"
-        >{% if group_id %}
+        >{% if group_id -%}
             {{ settings.WORDS_ASK_THE_GROUP|escape }}
-        {% else %}
+        {%- else -%}
             {{ settings.WORDS_ASK_YOUR_QUESTION|escape }}
-        {% endif %}</a>
+        {%- endif %}</a>
 {% endif %}


### PR DESCRIPTION
Newlines within the content of this anchor element cause any content included via an 'after' css pseudo element to slip down the page "to the
next line" in Chrome - see https://trello.com/c/QCto1N1x/116-big-ask-button-right-arrow-not-visible-in-chrome. We've fixed that instance via custom css quick fix, but this is the proper fix - we can make django ignore the leading and trailing whitespace in the template (whose purpose is to make the template more
readable) by judicious use of the hyphen character within the enclosing
if/else/endif template tags.

Generated markup before:

    <a
        id="askButton"
        class="button"
        href="/en/questions/ask/"
        >
            Ask Your Question
        </a>

Generated markup after:

    <a
        id="askButton"
        class="button"
        href="/en/questions/ask/"
        >Ask Your Question</a>