### PR TITLE
Show 'country' field in admin changelist for User model

### DIFF
--- a/askbot/admin.py
+++ b/askbot/admin.py
@@ -369,7 +369,7 @@ finally:
 
     from django.contrib.auth.admin import UserAdmin as OrigUserAdmin
     class UserAdmin(OrigUserAdmin):
-        list_display = OrigUserAdmin.list_display + ('languages', 
+        list_display = OrigUserAdmin.list_display + ('languages', 'country', 
             'date_joined', 'reputation', 
             'is_administrator', 'status', 'is_moderator', 'is_fake', 'email_isvalid',
             'my_interesting_tags', 'interesting_tag_wildcards',
@@ -378,6 +378,7 @@ finally:
             'email_tag_filter_strategy', 'display_tag_filter_strategy', 
             'get_groups', 'get_primary_group', 'get_default_site')
         list_filter = OrigUserAdmin.list_filter + (IsAdministrator, 'status', IsModerator, 'is_fake', 'email_isvalid', 'email_tag_filter_strategy', 'display_tag_filter_strategy', SeesThreadsInLanguage, InGroup)
+        search_fields = OrigUserAdmin.search_fields + ('country',)
 
         def interesting_tag_wildcards(self, obj):
             return ', '.join(obj.interesting_tags.strip().split())


### PR DESCRIPTION
Also allow searching by it - not easy because user has to know the iso code to search for
(eg. 'gb' for the UK, searching for 'uk' or 'United Kingdom' etc
won't work), but there are far too many possible values for a filter to
be practical.