### PR TITLE
Fix retrieving falsy hardcoded settings

### DIFF
--- a/askbot/conf/settings_wrapper.py
+++ b/askbot/conf/settings_wrapper.py
@@ -218,7 +218,7 @@ class ConfigSettings(object):
         out = dict()
         for key in cls.__instance.keys():
             hardcoded_setting = getattr(django_settings, 'ASKBOT_' + key, None)
-            if hardcoded_setting:
+            if hardcoded_setting is not None:
                 value = hardcoded_setting
             else:
                 setting_value = cls.__instance[key]


### PR DESCRIPTION
This fixes hardcoded settings with falsy values; for example: `ASKBOT_ENABLE_SHARING_GOOGLE = False`.