### PR TITLE
Fix avatar size check/string formatting exception

### DIFF
--- a/askbot/models/__init__.py
+++ b/askbot/models/__init__.py
@@ -255,10 +255,10 @@ def user_calculate_avatar_url(self, size=48):
     elif avatar_type == 'a':
         from avatar.conf import settings as avatar_settings
         sizes = avatar_settings.AVATAR_AUTO_GENERATE_SIZES
-        if size not in sizes:
+        if int(size) not in sizes:
             logging.critical(
                 'add values %d to setting AVATAR_AUTO_GENERATE_SIZES',
-                size
+                int(size)
             )
 
         from avatar.util import get_primary_avatar


### PR DESCRIPTION
Fixes the following exception (from `askbot/models/__init__.py`):
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/logging/__init__.py", line 851, in emit
    msg = self.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 724, in format
    return fmt.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 464, in format
    record.message = record.getMessage()
  File "/usr/lib/python2.7/logging/__init__.py", line 328, in getMessage
    msg = msg % self.args
TypeError: %d format: a number is required, not str
Logged from file __init__.py, line 261
```
Note that there are two connected issues to be fixed:
- `AVATAR_AUTO_GENERATE_SIZES` check always fails since a string will never be in a list of ints
- logging call raises an exception since we're trying to format a string with "%d"