### PR TITLE
Simplify tab

### DIFF
--- a/askbot/templates/main_page/tab_bar.html
+++ b/askbot/templates/main_page/tab_bar.html
@@ -38,7 +38,7 @@
         {% endif %}
         {{ macros.reversible_sort_button(
                 button_sort_criterium = 'age',
-                label = gettext('by date'),
+                label = gettext('date'),
                 asc_tooltip = gettext('click to see the oldest questions'),
                 desc_tooltip = gettext('click to see the newest questions'),
                 current_sort_method = sort,
@@ -47,7 +47,7 @@
         }}
         {{macros.reversible_sort_button(
                 button_sort_criterium = 'activity',
-                label = gettext('by activity'),
+                label = gettext('activity'),
                 asc_tooltip = gettext('click to see the least recently updated questions'),
                 desc_tooltip = gettext('click to see the most recently updated questions'),
                 current_sort_method = sort,
@@ -56,7 +56,7 @@
         }}
         {{macros.reversible_sort_button(
                 button_sort_criterium = 'answers',
-                label = gettext('by answers'),
+                label = gettext('answers'),
                 asc_tooltip = gettext('click to see the least answered questions'),
                 desc_tooltip = gettext('click to see the most answered questions'),
                 current_sort_method = sort,
@@ -65,7 +65,7 @@
         }}
         {{macros.reversible_sort_button(
                 button_sort_criterium = 'votes',
-                label = gettext('by votes'),
+                label = gettext('votes'),
                 asc_tooltip = gettext('click to see least voted questions'),
                 desc_tooltip = gettext('click to see most voted questions'),
                 current_sort_method = sort,


### PR DESCRIPTION
I removed "by" with all labels because it is already written in start of tab-bar.
So it make it without repetition, even in translations. 