### PR TITLE
Fixes for TINYMCE_PLUGINS

### DIFF
--- a/askbot/setup_templates/settings.py
+++ b/askbot/setup_templates/settings.py
@@ -291,7 +291,6 @@ TINYMCE_DEFAULT_CONFIG = {
     'forced_root_block': '',
     'mode' : 'textareas',
     'oninit': "TinyMCE.onInitHook",
-    'plugins': 'askbot_imageuploader,askbot_attachment',
     'theme_advanced_toolbar_location' : 'top',
     'theme_advanced_toolbar_align': 'left',
     'theme_advanced_buttons1': 'bold,italic,underline,|,bullist,numlist,|,undo,redo,|,link,unlink,askbot_imageuploader,askbot_attachment',

--- a/askbot/setup_templates/settings.py.mustache
+++ b/askbot/setup_templates/settings.py.mustache
@@ -280,7 +280,6 @@ TINYMCE_DEFAULT_CONFIG = {
     'forced_root_block': '',
     'mode' : 'textareas',
     'oninit': 'TinyMCE.onInitHook',
-    'plugins': 'askbot_imageuploader,askbot_attachment',
     'theme_advanced_toolbar_location' : 'top',
     'theme_advanced_toolbar_align': 'left',
     'theme_advanced_buttons1': 'bold,italic,underline,|,bullist,numlist,|,undo,redo,|,link,unlink,askbot_imageuploader,askbot_attachment',

--- a/askbot/templates/editors/rich_text.html
+++ b/askbot/templates/editors/rich_text.html
@@ -30,7 +30,7 @@
                 django.jQuery = $;
             </script>
             <script type="text/javascript">
-                askbot['settings']['tinyMCEPlugins'] = JSON.parse('{{ settings.TINYMCE_PLUGINS|as_json }}');
+                askbot['settings']['tinyMCEPlugins'] = JSON.parse('{{ TINYMCE_PLUGINS|as_json }}');
             </script>
             {{ post_form.media }}
             {{ post_form.text }}


### PR DESCRIPTION
TINYMCE_PLUGINS are added to the template context (askbot/context.py) so using {{ settings.TINYMCE_PLUGINS }} in rich_text.html template raised KeyError.

'plugins' key was duplicated in TINYMCE_DEFAULT_CONFIG