### PR TITLE
Added custom markdown parser

### DIFF
--- a/askbot/conf/forum_data_rules.py
+++ b/askbot/conf/forum_data_rules.py
@@ -14,8 +14,8 @@ FORUM_DATA_RULES = livesettings.ConfigurationGroup(
 )
 
 EDITOR_CHOICES = (
-    ('markdown', 'markdown'),
-    ('tinymce', 'WYSIWYG (tinymce)')
+    ('markdown', _('Markdown')),
+    ('tinymce', _('WYSIWYG (tinymce)')),
 )
 
 settings.register(
@@ -25,6 +25,16 @@ settings.register(
         default='markdown',
         choices=EDITOR_CHOICES,
         description=_('Editor for the posts')
+    )
+)
+
+settings.register(
+    livesettings.StringValue(
+        FORUM_DATA_RULES,
+        'MARKDOWN_CLASS',
+        default='markdown2.Markdown',
+        description=_('Custom Markdown class if you want to customize the '
+                      'markdown templating')
     )
 )
 
@@ -57,13 +67,12 @@ settings.register(
     )
 )
 
-
 settings.register(
     livesettings.BooleanValue(
         FORUM_DATA_RULES,
         'ENABLE_VIDEO_EMBEDDING',
         default=False,
-        description=_('Enable embedding videos. '),
+        description=_('Enable embedding videos.'),
         help_text=_(
             '<em>Note: please read <a href="%(url)s">read this</a> first.</em>'
         ) % {'url': const.DEPENDENCY_URLS['embedding-video']}

--- a/askbot/conf/forum_data_rules.py
+++ b/askbot/conf/forum_data_rules.py
@@ -28,16 +28,6 @@ settings.register(
     )
 )
 
-settings.register(
-    livesettings.StringValue(
-        FORUM_DATA_RULES,
-        'MARKDOWN_CLASS',
-        default='markdown2.Markdown',
-        description=_('Custom Markdown class if you want to customize the '
-                      'markdown templating')
-    )
-)
-
 COMMENTS_EDITOR_CHOICES = (
     ('plain-text', 'Plain text editor'),
     ('rich-text', 'Same editor as for questions and answers')

--- a/askbot/tests/utils.py
+++ b/askbot/tests/utils.py
@@ -1,10 +1,12 @@
 """utility functions used by Askbot test cases
 """
+from functools import wraps
+from markdown2 import Markdown
 from django.core.cache import cache
 from django.test import TestCase
-from functools import wraps
 from askbot import models
 from askbot import signals
+
 
 def with_settings(**settings_dict):
     """a decorator that will run function with settings

--- a/askbot/tests/utils_tests.py
+++ b/askbot/tests/utils_tests.py
@@ -1,3 +1,4 @@
+import markdown2
 from django.test import TestCase
 from askbot.tests.utils import with_settings
 from askbot.utils.url_utils import urls_equal
@@ -121,4 +122,8 @@ class HTMLUtilsTests(TestCase):
 class GetParserTest(TestCase):
     def test_func(self):
         parser = get_parser()
-        import ipdb; ipdb.set_trace()
+        self.assertIsInstance(parser, markdown2.Markdown)
+
+    def test_markdown_class_addr(self):
+        parser = get_parser('askbot.tests.utils.Markdown')
+        self.assertIsInstance(parser, markdown2.Markdown)

--- a/askbot/tests/utils_tests.py
+++ b/askbot/tests/utils_tests.py
@@ -4,7 +4,9 @@ from askbot.utils.url_utils import urls_equal
 from askbot.utils.html import absolutize_urls
 from askbot.utils.html import replace_links_with_text
 from askbot.utils.html import get_text_from_html
+from askbot.utils.markup import get_parser
 from askbot.conf import settings as askbot_settings
+
 
 class UrlUtilsTests(TestCase):
 
@@ -72,6 +74,7 @@ class ReplaceLinksWithTextTests(TestCase):
             'https://example.com/some-image.gif (picture)'
         )
 
+
 class HTMLUtilsTests(TestCase):
     """tests for :mod:`askbot.utils.html` module"""
     @with_settings(APP_URL='http://example.com')
@@ -113,3 +116,9 @@ class HTMLUtilsTests(TestCase):
             get_text_from_html('ataoesa uau <a>link</a>aueaotuosu ao <a href="http://cnn.com">CNN!</a>\nnaouaouuau<img> <img src="http://cnn.com/1.png"/> <img src="http://cnn.com/2.png" alt="sometext">'),
             u'ataoesa uau linkaueaotuosu ao http://cnn.com (CNN!)\n\nnaouaouuau http://cnn.com/1.png http://cnn.com/2.png (sometext)'
         )
+
+
+class GetParserTest(TestCase):
+    def test_func(self):
+        parser = get_parser()
+        import ipdb; ipdb.set_trace()

--- a/askbot/utils/markup.py
+++ b/askbot/utils/markup.py
@@ -5,67 +5,62 @@ Twitter-style @mentions"""
 
 import re
 import logging
+
+from django.utils.html import urlize
+from django.utils.module_loading import import_string
+
 from askbot import const
 from askbot.conf import settings as askbot_settings
 from askbot.utils.functions import split_phrases
 from askbot.utils.html import sanitize_html
 from askbot.utils.html import strip_tags
 from askbot.utils.html import urlize_html
-from django.utils.html import urlize
-from markdown2 import Markdown
-#url taken from http://regexlib.com/REDetails.aspx?regexp_id=501
+
+# URL taken from http://regexlib.com/REDetails.aspx?regexp_id=501
 URL_RE = re.compile("((?<!(href|.src|data)=['\"])((http|https|ftp)\://([a-zA-Z0-9\.\-]+(\:[a-zA-Z0-9\.&amp;%\$\-]+)*@)*((25[0-5]|2[0-4][0-9]|[0-1]{1}[0-9]{2}|[1-9]{1}[0-9]{1}|[1-9])\.(25[0-5]|2[0-4][0-9]|[0-1]{1}[0-9]{2}|[1-9]{1}[0-9]{1}|[1-9]|0)\.(25[0-5]|2[0-4][0-9]|[0-1]{1}[0-9]{2}|[1-9]{1}[0-9]{1}|[1-9]|0)\.(25[0-5]|2[0-4][0-9]|[0-1]{1}[0-9]{2}|[1-9]{1}[0-9]{1}|[0-9])|localhost|([a-zA-Z0-9\-]+\.)*[a-zA-Z0-9\-]+\.(com|edu|gov|int|mil|net|org|biz|arpa|info|name|pro|aero|coop|museum|[a-zA-Z]{2}))(\:[0-9]+)*(/($|[a-zA-Z0-9\.\,\?\'\\\+&amp;%\$#\=~_\-]+))*))")
+
 
 def get_parser():
     """returns an instance of configured ``markdown2`` parser
     """
+    Markdown = import_string(askbot_settings.MARKDOWN_CLASS)
     extras = ['link-patterns', 'video']
 
-    if askbot_settings.ENABLE_MATHJAX or \
-        askbot_settings.MARKUP_CODE_FRIENDLY:
+    if askbot_settings.ENABLE_MATHJAX or askbot_settings.MARKUP_CODE_FRIENDLY:
         extras.append('code-friendly')
 
-    if askbot_settings.ENABLE_VIDEO_EMBEDDING:
-        #note: this requires a forked version of markdown2 module
-        #pip uninstall markdown2
-        #pip install -e git+git://github.com/andryuha/python-markdown2.git
-        extras.append('video')
-
-    #link_patterns = [
-    #    (URL_RE, r'\1'),
-    #]
+    # link_patterns = [
+    #     (URL_RE, r'\1'),
+    # ]
     link_patterns = []
     if askbot_settings.ENABLE_AUTO_LINKING:
         pattern_list = askbot_settings.AUTO_LINK_PATTERNS.split('\n')
         url_list = askbot_settings.AUTO_LINK_URLS.split('\n')
-        pairs = zip(pattern_list, url_list)#always takes equal number of items
+        pairs = zip(pattern_list, url_list)  # always takes equal number of items
         for item in pairs:
-            if item[0].strip() =='' or item[1].strip() == '':
+            if not item[0].strip() or not item[1].strip():
                 continue
             link_patterns.append(
-                (
-                    re.compile(item[0].strip()),
-                    item[1].strip()
-                )
+                (re.compile(item[0].strip()), item[1].strip())
             )
 
-        #Check whether  we have matching links for all key terms,
-        #Other wise we ignore the key terms
-        #May be we should do this test in update_callback?
-        #looks like this might be a defect of livesettings
-        #as there seems to be no way
-        #to validate entries that depend on each other
+        # Check whether  we have matching links for all key terms,
+        # Other wise we ignore the key terms
+        # May be we should do this test in update_callback?
+        # looks like this might be a defect of livesettings
+        # as there seems to be no way
+        # to validate entries that depend on each other
         if len(pattern_list) != len(url_list):
             settings_url = askbot_settings.APP_URL+'/settings/AUTOLINK/'
-            logging.critical(
-                "Number of autolink patterns didn't match the number "
-                "of url templates, fix this by visiting" + settings_url)
+            msg = "Number of autolink patterns didn't match the number "\
+                  "of url templates, fix this by visiting %s"
+            logging.critical(msg, settings_url)
 
     return Markdown(
-                html4tags=True,
-                extras=extras,
-                link_patterns=link_patterns
-            )
+        html4tags=True,
+        extras=extras,
+        link_patterns=link_patterns
+    )
 
 
 def format_mention_in_html(mentioned_user):
@@ -74,13 +69,14 @@ def format_mention_in_html(mentioned_user):
     username = mentioned_user.username
     return '<a href="%s">@%s</a>' % (url, username)
 
+
 def extract_first_matching_mentioned_author(text, anticipated_authors):
     """matches beginning of ``text`` string with the names
     of ``anticipated_authors`` - list of user objects.
     Returns upon first match the first matched user object
     and the remainder of the ``text`` that is left unmatched"""
 
-    if len(text) == 0:
+    if not text:
         return None, ''
 
     for author in anticipated_authors:
@@ -91,11 +87,12 @@ def extract_first_matching_mentioned_author(text, anticipated_authors):
             elif text[ulen] in const.TWITTER_STYLE_MENTION_TERMINATION_CHARS:
                 text = text[ulen:]
             else:
-                #near miss, here we could insert a warning that perhaps
-                #a termination character is needed
+                # near miss, here we could insert a warning that perhaps
+                # a termination character is needed
                 continue
             return author, text
     return None, text
+
 
 def extract_mentioned_name_seeds(text):
     """Returns list of strings that
@@ -108,7 +105,7 @@ def extract_mentioned_name_seeds(text):
     extra_name_seeds = set()
     while '@' in text:
         pos = text.index('@')
-        text = text[pos+1:]#chop off prefix
+        text = text[pos+1:]  # chop off prefix
         name_seed = ''
         for char in text:
             if char in const.TWITTER_STYLE_MENTION_TERMINATION_CHARS:
@@ -126,10 +123,11 @@ def extract_mentioned_name_seeds(text):
                 break
             name_seed += char
         if len(name_seed) > 0:
-            #in case we run off the end of text
+            # in case we run off the end of text
             extra_name_seeds.add(name_seed)
 
     return extra_name_seeds
+
 
 def mentionize_text(text, anticipated_authors):
     """Returns a tuple of two items:
@@ -140,18 +138,18 @@ def mentionize_text(text, anticipated_authors):
     output = ''
     mentioned_authors = list()
     while '@' in text:
-        #the purpose of this loop is to convert any occurance of
-        #'@mention ' syntax
-        #to user account links leading space is required unless @ is the first
-        #character in whole text, also, either a punctuation or
-        #a ' ' char is required after the name
+        # the purpose of this loop is to convert any occurance of
+        # '@mention ' syntax
+        # to user account links leading space is required unless @ is the first
+        # character in whole text, also, either a punctuation or
+        # a ' ' char is required after the name
         pos = text.index('@')
 
-        #save stuff before @mention to the output
-        output += text[:pos]#this works for pos == 0 too
+        # save stuff before @mention to the output
+        output += text[:pos]  # this works for pos == 0 too
 
         if len(text) == pos + 1:
-            #finish up if the found @ is the last symbol
+            # finish up if the found @ is the last symbol
             output += '@'
             text = ''
             break
@@ -159,14 +157,12 @@ def mentionize_text(text, anticipated_authors):
         if pos > 0:
 
             if text[pos-1] in const.TWITTER_STYLE_MENTION_TERMINATION_CHARS:
-                #if there is a termination character before @mention
-                #indeed try to find a matching person
+                # if there is a termination character before @mention
+                # indeed try to find a matching person
                 text = text[pos+1:]
                 mentioned_author, text = \
-                                    extract_first_matching_mentioned_author(
-                                                            text,
-                                                            anticipated_authors
-                                                        )
+                    extract_first_matching_mentioned_author(
+                        text, anticipated_authors)
                 if mentioned_author:
                     mentioned_authors.append(mentioned_author)
                     output += format_mention_in_html(mentioned_author)
@@ -174,31 +170,31 @@ def mentionize_text(text, anticipated_authors):
                     output += '@'
 
             else:
-                #if there isn't, i.e. text goes like something@mention,
-                #do not look up people
+                # if there isn't, i.e. text goes like something@mention,
+                # do not look up people
                 output += '@'
                 text = text[pos+1:]
         else:
-            #do this if @ is the first character
+            # do this if @ is the first character
             text = text[1:]
             mentioned_author, text = \
-                                extract_first_matching_mentioned_author(
-                                                    text,
-                                                    anticipated_authors
-                                                )
+                extract_first_matching_mentioned_author(
+                    text, anticipated_authors)
             if mentioned_author:
                 mentioned_authors.append(mentioned_author)
                 output += format_mention_in_html(mentioned_author)
             else:
                 output += '@'
 
-    #append the rest of text that did not have @ symbols
+    # append the rest of text that did not have @ symbols
     output += text
     return mentioned_authors, output
+
 
 def plain_text_input_converter(text):
     """plain text to html converter"""
     return sanitize_html(urlize('<p>' + text + '</p>'))
+
 
 def markdown_input_converter(text):
     """markdown to html converter"""
@@ -207,10 +203,12 @@ def markdown_input_converter(text):
     text = urlize_html(text)
     return sanitize_html(text)
 
+
 def tinymce_input_converter(text):
     """tinymce input to production html converter"""
     text = urlize_html(text)
     return strip_tags(text, ['script', 'style', 'link'])
+
 
 def convert_text(text):
     parser_type = askbot_settings.EDITOR_TYPE
@@ -222,6 +220,7 @@ def convert_text(text):
         return tinymce_input_converter(text)
     else:
         raise NotImplementedError
+
 
 def find_forbidden_phrase(text):
     """returns string or None"""

--- a/askbot/utils/markup.py
+++ b/askbot/utils/markup.py
@@ -20,10 +20,19 @@ from askbot.utils.html import urlize_html
 URL_RE = re.compile("((?<!(href|.src|data)=['\"])((http|https|ftp)\://([a-zA-Z0-9\.\-]+(\:[a-zA-Z0-9\.&amp;%\$\-]+)*@)*((25[0-5]|2[0-4][0-9]|[0-1]{1}[0-9]{2}|[1-9]{1}[0-9]{1}|[1-9])\.(25[0-5]|2[0-4][0-9]|[0-1]{1}[0-9]{2}|[1-9]{1}[0-9]{1}|[1-9]|0)\.(25[0-5]|2[0-4][0-9]|[0-1]{1}[0-9]{2}|[1-9]{1}[0-9]{1}|[1-9]|0)\.(25[0-5]|2[0-4][0-9]|[0-1]{1}[0-9]{2}|[1-9]{1}[0-9]{1}|[0-9])|localhost|([a-zA-Z0-9\-]+\.)*[a-zA-Z0-9\-]+\.(com|edu|gov|int|mil|net|org|biz|arpa|info|name|pro|aero|coop|museum|[a-zA-Z]{2}))(\:[0-9]+)*(/($|[a-zA-Z0-9\.\,\?\'\\\+&amp;%\$#\=~_\-]+))*))")
 
 
-def get_parser():
-    """returns an instance of configured ``markdown2`` parser
+def get_parser(markdown_class_addr=None):
     """
-    Markdown = import_string(askbot_settings.MARKDOWN_CLASS)
+    Returns an instance of configured :class:`markdown2.Markdown parser.
+
+    :param markdown_class_addr: Path to :class:`markdown2.Markdown` custom
+                                class. (default: `'markdown2.Markdown'`)
+    :type markdown_class_addr: ``str``
+    """
+    if markdown_class_addr is None:
+        from django.conf import settings as django_settings
+        markdown_class_addr = getattr(django_settings, 'ASKBOT_MARKDOWN_CLASS',
+                                      'markdown2.Markdown')
+    Markdown = import_string(markdown_class_addr)
     extras = ['link-patterns', 'video']
 
     if askbot_settings.ENABLE_MATHJAX or askbot_settings.MARKUP_CODE_FRIENDLY:


### PR DESCRIPTION
I notice that `markdown2` has a hook system: https://github.com/trentm/python-markdown2/blob/fc438b576a2a6e82acebb0b2ac698e1e93a7b86e/lib/markdown2.py#L367

With the new option `MARKDOWN_CLASS`, I let admin choose their parser class. The can override the `markdown2.Markdown` and define this in this setting. Askbot will use their class with hooks.

I also PEP8-ize & add a test.
