### PR TITLE
Fixed JS escaping of settings note

### DIFF
--- a/askbot/templates/question.html
+++ b/askbot/templates/question.html
@@ -420,8 +420,8 @@
         askbot['messages']['addComment'] = '{% trans %}add a comment{% endtrans %}';
         askbot['messages']['userNamePrompt'] = '{% trans %}User name:{% endtrans %}';
         askbot['messages']['userEmailPrompt'] = '{% trans %}Email address:{% endtrans %}';
-        askbot['messages']['mergeQuestions'] = '{{ settings.WORDS_MERGE_QUESTIONS }}';
-        askbot['messages']['enterDuplicateQuestionId'] = '{{ settings.WORDS_ENTER_DUPLICATE_QUESTION_ID }}';
+        askbot['messages']['mergeQuestions'] = '{{ settings.WORDS_MERGE_QUESTIONS|escapejs }}';
+        askbot['messages']['enterDuplicateQuestionId'] = '{{ settings.WORDS_ENTER_DUPLICATE_QUESTION_ID|escapejs }}';
         {% if settings.READ_ONLY_MODE_ENABLED %}
             askbot['messages']['readOnlyMessage'] = "{{ settings.READ_ONLY_MESSAGE }}";
         {% endif %}


### PR DESCRIPTION
With the new french translations my question view's JS is broken.
There is `askbot['messages']['acceptOwnAnswer'] = 'accepter ou non accepter votre propre réponse';` in code.

What JS considers as syntax error. I just use the filter ``escapejs``.