### PR TITLE
Update import for django-avatar.utils

### DIFF
--- a/askbot/models/__init__.py
+++ b/askbot/models/__init__.py
@@ -287,7 +287,14 @@ def user_calculate_avatar_url(self, size=48):
                 size
             )
 
-        from avatar.util import get_primary_avatar
+        try:
+            from avatar.utils import get_primary_avatar
+        except ImportError, error:
+            # If the updated version of django-avatar isn't installed
+            # Let's fall back
+            from avatar.util import get_primary_avatar
+            logging.warning("Using deprecated version of django-avatar")
+
         avatar = get_primary_avatar(self, size=size)
         if avatar:
             return avatar.avatar_url(size)


### PR DESCRIPTION
Due to a change in django-avatar updated versions will break certain views with the old util name. This change would import the new utils name and fall back if it fails.

Solves:
https://github.com/ASKBOT/askbot-devel/issues/593
and
https://github.com/ASKBOT/askbot-devel/issues/567