### PR TITLE
Fix typo: adddresses -> addresses

### DIFF
--- a/askbot/conf/group_settings.py
+++ b/askbot/conf/group_settings.py
@@ -50,7 +50,7 @@ settings.register(
         GROUP_SETTINGS,
         'GROUP_EMAIL_ADDRESSES_ENABLED',
         default=False,
-        description=_('Enable group email adddresses'),
+        description=_('Enable group email addresses'),
         help_text=_('If selected, users can post to groups by email'
                     '"group-name@domain.com"')
     )


### PR DESCRIPTION
Found a typo while I was helping translate askbot to Basque language.

"Enable group email adddresses" -> "Enable group email addresses"