### PR TITLE
Add missing spaces

### DIFF
--- a/askbot/conf/group_settings.py
+++ b/askbot/conf/group_settings.py
@@ -51,7 +51,7 @@ settings.register(
         'GROUP_EMAIL_ADDRESSES_ENABLED',
         default=False,
         description=_('Enable group email addresses'),
-        help_text=_('If selected, users can post to groups by email'
+        help_text=_('If selected, users can post to groups by email '
                     '"group-name@domain.com"')
     )
 )

--- a/askbot/conf/leading_sidebar.py
+++ b/askbot/conf/leading_sidebar.py
@@ -29,7 +29,7 @@ settings.register(
         description=_('HTML for the left sidebar'),
         default='',
         help_text=_(
-            'Use this area to enter content at the LEFT sidebar'
+            'Use this area to enter content at the LEFT sidebar '
             'in HTML format.  When using this option, please '
             'use the HTML validation service to make sure that '
             'your input is valid and works well in all browsers.'

--- a/askbot/conf/sidebar_main.py
+++ b/askbot/conf/sidebar_main.py
@@ -88,7 +88,7 @@ settings.register(
         default='',
         localized=True,
         help_text=_(
-                    'Use this area to enter content at the BOTTOM of the sidebar'
+                    'Use this area to enter content at the BOTTOM of the sidebar '
                     'in HTML format.   When using this option '
                     '(as well as the sidebar header), please '
                     'use the HTML validation service to make sure that '

--- a/askbot/conf/skin_general_settings.py
+++ b/askbot/conf/skin_general_settings.py
@@ -50,7 +50,7 @@ settings.register(
         'SITE_LOGO_URL',
         description=_('Q&amp;A site logo'),
         help_text=_(
-            'To change the logo, select new file, then submit'
+            'To change the logo, select new file, then submit '
             'this whole form.'),
         default='/images/logo.gif',
         url_resolver=skin_utils.get_media_url


### PR DESCRIPTION
Ander Elortondo and Xalba from the Basque translation team Librezale spotted 4 strings that were missing spaces:

Use this area to enter content at the LEFT sidebarin HTML format. -> Use this area to enter content at the LEFT sidebar in HTML format.

Use this area to enter content at the BOTTOM of the sidebarin HTML format. -> Use this area to enter content at the BOTTOM of the sidebar in HTML format.

If selected, users can post to groups by email"group-name@domain.com" -> If selected, users can post to groups by email "group-name@domain.com"

"To change the logo, select new file, then submitthis whole form" -> "To change the logo, select new file, then submit this whole form"