### PR TITLE
Use correct package name for appconf module (django-appconf)

### DIFF
--- a/askbot/__init__.py
+++ b/askbot/__init__.py
@@ -14,7 +14,7 @@ default_app_config = 'askbot.apps.AskbotConfig'
 #keys are module names used by python imports,
 #values - the package qualifier to use for pip
 REQUIREMENTS = {
-    'appconf': 'appconf',
+    'appconf': 'django-appconf',
     'akismet': 'akismet<=0.2.0',
     'avatar': 'django-avatar==2.2.1',
     'bs4': 'beautifulsoup4<=4.4.1',


### PR DESCRIPTION
Without this, `python setup.py develop` fails by trying to install the nonexistent `appconf` package.