### PR TITLE
return to older html=>text email conversion

### DIFF
--- a/askbot/utils/html.py
+++ b/askbot/utils/html.py
@@ -200,7 +200,6 @@ def get_text_from_html(html_text):
     retains links and references to images and line breaks.
     """
     soup = BeautifulSoup(html_text, 'html5lib')
-    return soup.text
 
     # replace <a> links with plain text
     links = soup.find_all('a')


### PR DESCRIPTION
The early return in `get_text_from_html` was added in 89e27a9719 for no very obvious reason, but leads to a giant CSS blob at the top of any plain-text email, in addition to worse line breaking. Since I don't know the rationale for removing it in that commit I'm not sure, but reverting the removal seems like the right thing.