### PR TITLE
missing test dependency

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,3 +1,4 @@
 factory_boy
 coverage
 dj-database-url
+django_lamson


### PR DESCRIPTION
This module is required by the askbot self-test that runs before running the rest of the tests:

```
$ coverage run manage.py test askbot.tests


************************
*                      *
*   Askbot self-test   *
*                      *
************************

Error: No module named django_lamson

Please run: >pip install django-lamson
Lamson modules are required for running tests
and for making posts by email

Type ^C to quit.

If necessary, type ^C (Ctrl-C) to stop the program
(to disable the self-test add ASKBOT_SELF_TEST = False).
```