### PR TITLE
Use `collections.OrderedDict`

### DIFF
--- a/askbot/deps/django_authopenid/util.py
+++ b/askbot/deps/django_authopenid/util.py
@@ -7,6 +7,7 @@ import random
 import re
 import urllib
 import urlparse
+from collections import OrderedDict
 from askbot.utils.html import site_url
 from askbot.utils.functions import format_setting_name
 from askbot.utils.loading import load_module, module_exists
@@ -19,7 +20,6 @@ from django.db.models.query import Q
 from django.conf import settings
 from django.core.urlresolvers import reverse
 import simplejson
-from django.utils.datastructures import SortedDict
 from django.utils.translation import ugettext as _
 from django.core.exceptions import ImproperlyConfigured
 from askbot.deps.django_authopenid import providers
@@ -424,7 +424,7 @@ def get_enabled_major_login_providers():
       and consumer secret. The purpose of this function is to hide the differences
       between the ways user id is accessed from the different OAuth providers
     """
-    data = SortedDict()
+    data = OrderedDict()
 
     if use_password_login():
         site_name = askbot_settings.APP_SHORT_NAME
@@ -633,7 +633,7 @@ def get_enabled_minor_login_providers():
 
     structure of dictionary values is the same as in get_enabled_major_login_providers
     """
-    data = SortedDict()
+    data = OrderedDict()
     #data['myopenid'] = {
     #    'name': 'myopenid',
     #    'display_name': 'MyOpenid',

--- a/askbot/deps/livesettings/values.py
+++ b/askbot/deps/livesettings/values.py
@@ -4,12 +4,12 @@
 http://code.google.com/p/django-values/
 """
 from decimal import Decimal
+from collections import OrderedDict
 from django import forms
 from django.conf import settings as django_settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.cache import cache
 import simplejson
-from django.utils.datastructures import SortedDict
 from django.utils.encoding import force_unicode
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
@@ -22,7 +22,6 @@ from askbot.deps.livesettings.overrides import get_overrides
 from askbot.deps.livesettings.utils import load_module, is_string_like, is_list_or_tuple
 from askbot.deps.livesettings.widgets import ImageInput
 from askbot.utils.functions import format_setting_name
-from collections import OrderedDict
 import datetime
 import logging
 import signals
@@ -42,24 +41,100 @@ NOTSET = object()
 def get_language():
     return _get_language() or django_settings.LANGUAGE_CODE
 
-class SortedDotDict(SortedDict):
+
+class SortedDotDict(object):
+    def __init__(self, *args, **kwargs):
+        super(SortedDotDict, self).__init__(*args, **kwargs)
+        self._dict = OrderedDict()
+
+    def __contains__(self, *args, **kwargs):
+        return self._dict.__contains__(*args, **kwargs)
+
+    def __eq__(self, *args, **kwargs):
+        return self._dict.__eq__(*args, **kwargs)
+
+    def __format__(self, *args, **kwargs):
+        return self._dict.__format__(*args, **kwargs)
+
+    def __ge__(self, *args, **kwargs):
+        return self._dict.__ge__(*args, **kwargs)
 
     def __getattr__(self, key):
         try:
-            return self[key]
+            return self._dict[key]
         except:
-            raise AttributeError, key
+            raise AttributeError(key)
 
     def __iter__(self):
         vals = self.values()
         for k in vals:
             yield k
 
+    def __getitem__(self, key):
+        return self._dict[key]
+
+    def __setitem__(self, key, value):
+        self._dict[key] = value
+
+    def __delitem__(self, key):
+        del self._dict[key]
+
+    def keys(self):
+        return self._dict.keys()
+
     def values(self):
-        vals = super(SortedDotDict, self).values()
+        vals = self._dict.values()
         vals = [v for v in vals if isinstance(v, (ConfigurationGroup, Value))]
         vals.sort()
         return vals
+
+    def items(self):
+        return self._dict.items()
+
+    def iterkeys(self):
+        return self._dict.iterkeys()
+
+    def itervalues(self):
+        return self._dict.itervalues()
+
+    def iteritems(self):
+        return self._dict.iteritems()
+
+    def get(self, *args, **kwargs):
+        return self._dict.get(*args, **kwargs)
+
+    def clear(self):
+        return self._dict.clear()
+
+    def copy(self):
+        s = SortedDotDict()
+        s._dict = self._dict.copy()
+        return s
+
+    def fromkeys(self):
+        return self._dict.fromkeys()
+
+    def has_key(self, key):
+        return key in self._dict
+
+    def pop(self, *args, **kwargs):
+        return self._dict.pop(*args, **kwargs)
+
+    def popitem(self, *args, **kwargs):
+        return self._dict.popitem(*args, **kwargs)
+
+    def setdefault(self, key, default):
+        return self._dict.setdefault(key, default)
+
+    def update(self, d):
+        return self._dict.update(d)
+
+    def viewitems(self, *args, **kwargs):
+        return self._dict.viewitems(*args, **kwargs)
+
+    def viewvalues(self, *args, **kwargs):
+        return self._dict.viewvalues(*args, **kwargs)
+
 
 class SuperGroup(object):
     """Aggregates ConfigurationGroup's into super-groups

--- a/askbot/forms.py
+++ b/askbot/forms.py
@@ -4,6 +4,7 @@ import regex as re #todo: make explicit import
 import datetime
 import askbot
 import unicodedata
+from collections import OrderedDict
 from django import forms
 from askbot import const
 from askbot.const import message_keys
@@ -12,7 +13,6 @@ from django.core.exceptions import PermissionDenied
 from django.forms.util import ErrorList
 from django.utils import timezone
 from django.utils.html import strip_tags
-from django.utils.datastructures import SortedDict
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ungettext_lazy, string_concat
 from askbot.utils.translation import get_language
@@ -1511,7 +1511,7 @@ class EditUserEmailFeedsForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         super(EditUserEmailFeedsForm, self).__init__(*args, **kwargs)
-        self.fields = SortedDict((
+        self.fields = OrderedDict((
             ('asked_by_me', EmailFeedSettingField(label=askbot_settings.WORDS_ASKED_BY_ME)),
             ('answered_by_me', EmailFeedSettingField(label=askbot_settings.WORDS_ANSWERED_BY_ME)),
             ('individually_selected', EmailFeedSettingField(label=_('Individually selected'))),

--- a/askbot/management/commands/export_osqa.py
+++ b/askbot/management/commands/export_osqa.py
@@ -1,8 +1,8 @@
+from collections import OrderedDict
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.base import BaseCommand, CommandError
 from django.core.serializers.xml_serializer import Serializer
 from django.db import connections, router, DEFAULT_DB_ALIAS
-from django.utils.datastructures import SortedDict
 from StringIO import StringIO
 
 class XMLExportSerializer(Serializer):
@@ -86,9 +86,9 @@ class Command(BaseCommand):
                     raise CommandError('Unknown app in excludes: %s' % exclude)
 
         if len(app_labels) == 0:
-            app_list = SortedDict((app, None) for app in get_apps() if app not in excluded_apps)
+            app_list = OrderedDict((app, None) for app in get_apps() if app not in excluded_apps)
         else:
-            app_list = SortedDict()
+            app_list = OrderedDict()
             for label in app_labels:
                 try:
                     app_label, model_label = label.split('.')

--- a/askbot/management/commands/send_email_alerts.py
+++ b/askbot/management/commands/send_email_alerts.py
@@ -1,6 +1,7 @@
 import askbot
 import datetime
 import traceback
+from collections import OrderedDict
 
 from django.conf import settings as django_settings
 from django.contrib.contenttypes.models import ContentType
@@ -8,7 +9,6 @@ from django.contrib.sites.models import Site
 from django.core.management.base import NoArgsCommand
 from django.db import connection
 from django.db.models import Q, F
-from django.utils.datastructures import SortedDict
 from django.utils import timezone
 from django.utils.translation import ugettext as _
 from django.utils.translation import activate as activate_language
@@ -104,7 +104,7 @@ class Command(NoArgsCommand):
             connection.close()
 
     def format_debug_msg(self, user, content):
-        msg = u"%s site_id=%d user=%s: %s" % ( 
+        msg = u"%s site_id=%d user=%s: %s" % (
             timezone.now().strftime('%y-%m-%d %h:%m:%s'),
             SITE_ID,
             repr(user.username),
@@ -259,7 +259,7 @@ class Command(NoArgsCommand):
                     q_all_B.cutoff_time = cutoff_time
 
         #build ordered list questions for the email report
-        q_list = SortedDict()
+        q_list = OrderedDict()
 
         #todo: refactor q_list into a separate class?
         extend_question_list(q_sel_A, q_list, languages=languages)
@@ -374,8 +374,8 @@ class Command(NoArgsCommand):
                 emailed_at = update_info.active_at
             except Activity.DoesNotExist:
                 update_info = Activity(
-                                    user=user, 
-                                    content_object=q, 
+                                    user=user,
+                                    content_object=q,
                                     activity_type=EMAIL_UPDATE_ACTIVITY
                                 )
                 emailed_at = datetime.datetime(1970, 1, 1)  #long time ago
@@ -439,7 +439,7 @@ class Command(NoArgsCommand):
             else:
                 meta_data['skip'] = False
                 #print 'not skipping'
-                update_info.active_at = timezone.now() 
+                update_info.active_at = timezone.now()
                 if DEBUG_THIS_COMMAND == False:
                     update_info.save() #save question email update activity
         #q_list is actually an ordered dictionary

--- a/askbot/skins/utils.py
+++ b/askbot/skins/utils.py
@@ -9,9 +9,10 @@ import os
 import logging
 import urllib
 import askbot
+from collections import OrderedDict
 from askbot.utils import hasher
 from django.conf import settings as django_settings
-from django.utils.datastructures import SortedDict
+
 
 class MediaNotFound(Exception):
     """raised when media file is not found"""
@@ -21,7 +22,7 @@ def get_skins_from_dir(directory):
     """returns sorted dict with skin data, like get_available_skins
     but from a specific directory
     """
-    skins = SortedDict()
+    skins = OrderedDict()
     for item in sorted(os.listdir(directory)):
         item_dir = os.path.join(directory, item)
         if os.path.isdir(item_dir):
@@ -39,7 +40,7 @@ def get_available_skins(selected=None):
 
     selected skin is guaranteed to be the first item in the dictionary
     """
-    skins = SortedDict()
+    skins = OrderedDict()
     extra_skins_dir = getattr(django_settings, 'ASKBOT_EXTRA_SKINS_DIR', None)
     if extra_skins_dir:
         skins.update(get_skins_from_dir(extra_skins_dir))
@@ -52,7 +53,7 @@ def get_available_skins(selected=None):
         skins.clear()
         skins[selected] = selected_dir
     elif selected == 'default':
-        skins = SortedDict()
+        skins = OrderedDict()
     elif selected:
         raise ValueError(
             'skin ' + str(selected) + \


### PR DESCRIPTION
`django.utils.datastructures.SortedDict` is deprecated in Django 1.7 and removed in 1.9.