### PR TITLE
allow configuration of DB host and port when running askbot-setup

### DIFF
--- a/askbot/deployment/__init__.py
+++ b/askbot/deployment/__init__.py
@@ -70,6 +70,20 @@ def askbot_setup():
             )
 
     parser.add_option(
+                "--db-host",
+                dest = "database_host",
+                default = None,
+                help = "the database host"
+            )
+
+    parser.add_option(
+                "--db-port",
+                dest = "database_port",
+                default = None,
+                help = "the database host"
+            )
+
+    parser.add_option(
                 "--append-settings",
                 dest = "local_settings",
                 default = '',
@@ -221,7 +235,14 @@ def collect_missing_options(options_dict):
                 return options_dict
 
     else:#others
-        for key in ('database_name', 'database_user', 'database_password'):
+        db_keys = (
+            'database_name',
+            'database_user',
+            'database_password',
+            'database_host',
+            'database_port'
+            )
+        for key in db_keys:
             if options_dict[key] is None:
                 key_name = key.replace('_', ' ')
                 value = console.simple_dialog(

--- a/askbot/deployment/__init__.py
+++ b/askbot/deployment/__init__.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import os.path
 import sys
 import django
+from collections import OrderedDict
 from optparse import OptionParser
 from askbot.deployment import messages
 from askbot.deployment.messages import print_message
@@ -235,19 +236,19 @@ def collect_missing_options(options_dict):
                 return options_dict
 
     else:#others
-        db_keys = (
-            'database_name',
-            'database_user',
-            'database_password',
-            'database_host',
-            'database_port'
-            )
-        for key in db_keys:
+        db_keys = OrderedDict([
+            ('database_name', True),
+            ('database_user', True),
+            ('database_password', True),
+            ('database_host', False),
+            ('database_port', False)
+        ])
+        for key in db_keys.iterkeys():
             if options_dict[key] is None:
                 key_name = key.replace('_', ' ')
                 value = console.simple_dialog(
                     '\nPlease enter %s' % key_name,
-                    required=True
+                    required=db_keys[key]
                 )
                 options_dict[key] = value
         return options_dict

--- a/askbot/doc/source/initial-configuration.rst
+++ b/askbot/doc/source/initial-configuration.rst
@@ -64,6 +64,10 @@ in the same project.
     +----------------------------------+------------------------------------------------------------+
     | -p <DATABASE_PASSWORD>           | The database password for the user.                        |
     +----------------------------------+------------------------------------------------------------+
+    | --db-host <DATABASE_HOST>        | The database host to which askbot will connect             |
+    +----------------------------------+------------------------------------------------------------+
+    | --db-port <DATABASE_PORT>        | The database port to which askbot will connect.            |
+    +----------------------------------+------------------------------------------------------------+
     | --append-settings=<SETTINGS_FILE>| Allows to append a setting file content to the             |
     |                                  | settings file, the parameter is the file to use.           |
     +----------------------------------+------------------------------------------------------------+

--- a/askbot/setup_templates/settings.py.mustache
+++ b/askbot/setup_templates/settings.py.mustache
@@ -27,8 +27,8 @@ DATABASES = {
         'NAME': '{{database_name}}',                      # Or path to database file if using sqlite3.
         'USER': '{{database_user}}',                      # Not used with sqlite3.
         'PASSWORD': '{{database_password}}',                  # Not used with sqlite3.
-        'HOST': '',                      # Set to empty string for localhost. Not used with sqlite3.
-        'PORT': '',                      # Set to empty string for default. Not used with sqlite3.
+        'HOST': '{{database_host}}',                      # Set to empty string for localhost. Not used with sqlite3.
+        'PORT': '{{database_port}}',                      # Set to empty string for default. Not used with sqlite3.
         'TEST_CHARSET': 'utf8',              # Setting the character set and collation to utf-8
         'TEST_COLLATION': 'utf8_general_ci', # is necessary for MySQL tests to work properly.
     }


### PR DESCRIPTION
Fixes #712 by allowing db host and db port to be configured with the cli utility `askbot-setup` for the purpose of configuring the docker image to work with external databases.