### PR TITLE
Replace usage of `django.forms.util`

### DIFF
--- a/askbot/deps/django_authopenid/views.py
+++ b/askbot/deps/django_authopenid/views.py
@@ -42,7 +42,6 @@ from django.contrib.auth.models import User
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth import authenticate
 from django.core.urlresolvers import reverse
-from django.forms.util import ErrorList
 from django.shortcuts import render
 from django.template.loader import get_template
 from django.views.decorators import csrf
@@ -1077,7 +1076,7 @@ def finalize_generic_signin(
 
 @not_authenticated
 @csrf.csrf_protect
-def register(request, login_provider_name=None, 
+def register(request, login_provider_name=None,
     user_identifier=None, redirect_url=None):
     """
     this function is used via it's own url with request.method=POST

--- a/askbot/forms.py
+++ b/askbot/forms.py
@@ -1,7 +1,6 @@
 """Forms, custom form fields and related utility functions
 used in AskBot"""
 import regex as re #todo: make explicit import
-import datetime
 import askbot
 import unicodedata
 from collections import OrderedDict
@@ -10,7 +9,7 @@ from askbot import const
 from askbot.const import message_keys
 from django.conf import settings as django_settings
 from django.core.exceptions import PermissionDenied
-from django.forms.util import ErrorList
+from django.forms.utils import ErrorList
 from django.utils import timezone
 from django.utils.html import strip_tags
 from django.utils.translation import ugettext_lazy as _


### PR DESCRIPTION
`django.forms.util` is renamed to ``django.forms.utils`