### PR TITLE
Fix delete button being hidden when it shouldn't

### DIFF
--- a/askbot/templates/question.html
+++ b/askbot/templates/question.html
@@ -271,7 +271,7 @@
 
                 if (//maybe remove "delete" button
                     (data['userReputation'] <
-                    {{settings.MIN_REP_TO_DELETE_OTHERS_COMMENTS}}) || data['userIsReadOnly']
+                    {{settings.MIN_REP_TO_DELETE_OTHERS_POSTS}}) || data['userIsReadOnly']
                 ) {
                     removeNode(deleteBtn);
                 }


### PR DESCRIPTION
MIN_REP_TO_DELETE_OTHERS_COMMENTS was being used to check if delete button of questions should be hidden.