### PR TITLE
using OneToOneField

### DIFF
--- a/askbot/deps/group_messaging/models.py
+++ b/askbot/deps/group_messaging/models.py
@@ -99,7 +99,7 @@ class SenderList(models.Model):
     sender list is populated automatically
     as new messages are created
     """
-    recipient = models.ForeignKey(Group, unique=True)
+    recipient = models.OneToOneField(Group)
     senders = models.ManyToManyField(User)
     objects = SenderListManager()
 


### PR DESCRIPTION
Because Foreign key implicitly means unique = True.

Django suggests using models.OneToOneField

group_messaging.SenderList.recipient: (fields.W342) Setting unique=True on a ForeignKey has the same effect as using a OneToOneField.
    HINT: ForeignKey(unique=True) is usually better served by a OneToOneField.