### PR TITLE
Django1.7 deprecated apis

### DIFF
--- a/askbot/conf/access_control.py
+++ b/askbot/conf/access_control.py
@@ -3,9 +3,7 @@ from django.utils.translation import string_concat
 
 from askbot.conf.settings_wrapper import settings
 from askbot.conf.super_groups import LOGIN_USERS_COMMUNICATION
-from askbot.deps import livesettings
-from askbot.deps.livesettings import BooleanValue
-from askbot.deps.livesettings import StringValue
+from askbot.deps.livesettings import values as livesettings
 
 ACCESS_CONTROL = livesettings.ConfigurationGroup(
                     'ACCESS_CONTROL',
@@ -14,7 +12,7 @@ ACCESS_CONTROL = livesettings.ConfigurationGroup(
                 )
 
 settings.register(
-    BooleanValue(
+    livesettings.BooleanValue(
         ACCESS_CONTROL,
         'READ_ONLY_MODE_ENABLED',
         default=False,
@@ -23,7 +21,7 @@ settings.register(
 )
 
 settings.register(
-    StringValue(
+    livesettings.StringValue(
         ACCESS_CONTROL,
         'READ_ONLY_MESSAGE',
         default=_(

--- a/askbot/conf/badges.py
+++ b/askbot/conf/badges.py
@@ -8,9 +8,9 @@ from django.utils.translation import string_concat
 
 from askbot.conf.settings_wrapper import settings
 from askbot.conf.super_groups import REP_AND_BADGES
-from askbot.deps.livesettings import ConfigurationGroup
-from askbot.deps.livesettings import IntegerValue
-from askbot.deps.livesettings import BooleanValue
+from askbot.deps.livesettings.values import ConfigurationGroup
+from askbot.deps.livesettings.values import IntegerValue
+from askbot.deps.livesettings.values import BooleanValue
 
 BADGES = ConfigurationGroup(
     'BADGES', _('Badge settings'), ordering=2, super_group=REP_AND_BADGES)

--- a/askbot/conf/email.py
+++ b/askbot/conf/email.py
@@ -7,7 +7,7 @@ from django.conf import settings as django_settings
 
 from askbot.conf.settings_wrapper import settings
 from askbot.conf.super_groups import LOGIN_USERS_COMMUNICATION
-from askbot.deps import livesettings
+from askbot.deps.livesettings import values as livesettings
 from askbot import const
 
 EMAIL_SUBJECT_PREFIX = getattr(django_settings, 'EMAIL_SUBJECT_PREFIX', '')

--- a/askbot/conf/email_text.py
+++ b/askbot/conf/email_text.py
@@ -2,7 +2,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from askbot.conf.settings_wrapper import settings
 from askbot.conf.super_groups import LOGIN_USERS_COMMUNICATION
-from askbot.deps import livesettings
+from askbot.deps.livesettings import values as livesettings
 
 EMAIL_TEXT = livesettings.ConfigurationGroup(
             'EMAIL_TEXT',

--- a/askbot/conf/external_keys.py
+++ b/askbot/conf/external_keys.py
@@ -2,7 +2,7 @@
 from askbot import const
 from askbot.conf.settings_wrapper import settings
 from askbot.conf.super_groups import EXTERNAL_SERVICES
-from askbot.deps import livesettings
+from askbot.deps.livesettings import values as livesettings
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings as django_settings
 

--- a/askbot/conf/feedback.py
+++ b/askbot/conf/feedback.py
@@ -5,7 +5,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.core.validators import validate_email, ValidationError
 from askbot.conf.settings_wrapper import settings
 from askbot.conf.super_groups import LOGIN_USERS_COMMUNICATION
-from askbot.deps import livesettings
+from askbot.deps.livesettings import values as livesettings
 
 FEEDBACK = livesettings.ConfigurationGroup(
     'FEEDBACK',

--- a/askbot/conf/flatpages.py
+++ b/askbot/conf/flatpages.py
@@ -4,7 +4,7 @@ Q&A forum flatpages (about, etc.)
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import string_concat
 from askbot.conf.settings_wrapper import settings
-from askbot.deps.livesettings import ConfigurationGroup, LongStringValue
+from askbot.deps.livesettings.values import ConfigurationGroup, LongStringValue
 from askbot.conf.super_groups import CONTENT_AND_UI
 
 FLATPAGES = ConfigurationGroup(

--- a/askbot/conf/forum_data_rules.py
+++ b/askbot/conf/forum_data_rules.py
@@ -3,7 +3,7 @@ Settings for askbot data display and entry
 """
 from django.utils.translation import ugettext_lazy as _
 from askbot.conf.settings_wrapper import settings
-from askbot.deps import livesettings
+from askbot.deps.livesettings import values as livesettings
 from askbot import const
 from askbot.conf.super_groups import DATA_AND_FORMATTING
 

--- a/askbot/conf/group_settings.py
+++ b/askbot/conf/group_settings.py
@@ -2,7 +2,7 @@
 from django.utils.translation import ugettext_lazy as _
 from askbot.conf.settings_wrapper import settings
 from askbot.conf.super_groups import LOGIN_USERS_COMMUNICATION
-from askbot.deps import livesettings
+from askbot.deps.livesettings import values as livesettings
 
 GROUP_SETTINGS = livesettings.ConfigurationGroup(
     'GROUP_SETTINGS',

--- a/askbot/conf/karma_and_badges_visibility.py
+++ b/askbot/conf/karma_and_badges_visibility.py
@@ -4,7 +4,7 @@ the users at a different degree
 """
 from django.utils.translation import ugettext_lazy as _
 from askbot.conf.settings_wrapper import settings
-from askbot.deps import livesettings
+from askbot.deps.livesettings import values as livesettings
 from askbot.conf.super_groups import REP_AND_BADGES
 
 KARMA_AND_BADGE_VISIBILITY = livesettings.ConfigurationGroup(

--- a/askbot/conf/ldap.py
+++ b/askbot/conf/ldap.py
@@ -2,7 +2,7 @@
 from django.utils.translation import ugettext_lazy as _
 from askbot.conf.settings_wrapper import settings
 from askbot.conf.super_groups import EXTERNAL_SERVICES
-from askbot.deps import livesettings
+from askbot.deps.livesettings import values as livesettings
 
 LDAP_SETTINGS = livesettings.ConfigurationGroup(
     'LDAP_SETTINGS',

--- a/askbot/conf/leading_sidebar.py
+++ b/askbot/conf/leading_sidebar.py
@@ -3,7 +3,7 @@ Sidebar settings
 """
 from django.utils.translation import ugettext_lazy as _
 from askbot.conf.settings_wrapper import settings
-from askbot.deps.livesettings import ConfigurationGroup
+from askbot.deps.livesettings.values import ConfigurationGroup
 from askbot.deps.livesettings import values
 from askbot.conf.super_groups import CONTENT_AND_UI
 

--- a/askbot/conf/license.py
+++ b/askbot/conf/license.py
@@ -4,7 +4,7 @@ from django.utils.translation import ugettext_lazy as _
 from askbot import const
 from askbot.conf.settings_wrapper import settings
 from askbot.conf.super_groups import CONTENT_AND_UI
-from askbot.deps import livesettings
+from askbot.deps.livesettings import values as livesettings
 from askbot.skins import utils as skin_utils
 
 LICENSE_SETTINGS = livesettings.ConfigurationGroup(

--- a/askbot/conf/login_providers.py
+++ b/askbot/conf/login_providers.py
@@ -6,7 +6,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from askbot.conf.settings_wrapper import settings
 from askbot.conf.super_groups import LOGIN_USERS_COMMUNICATION
-from askbot.deps import livesettings
+from askbot.deps.livesettings import values as livesettings
 from askbot.skins import utils as skin_utils
 from askbot.utils.loading import module_exists
 

--- a/askbot/conf/markup.py
+++ b/askbot/conf/markup.py
@@ -6,8 +6,8 @@ import re
 from django.utils.translation import ugettext_lazy as _
 from askbot.conf.settings_wrapper import settings
 from askbot.conf.super_groups import DATA_AND_FORMATTING
-from askbot.deps.livesettings import ConfigurationGroup
-from askbot.deps.livesettings import BooleanValue, StringValue, LongStringValue
+from askbot.deps.livesettings.values import ConfigurationGroup
+from askbot.deps.livesettings.values import BooleanValue, StringValue, LongStringValue
 from askbot import const
 
 MARKUP = ConfigurationGroup(

--- a/askbot/conf/minimum_reputation.py
+++ b/askbot/conf/minimum_reputation.py
@@ -5,7 +5,7 @@ a variety of actions on the askbot askbot
 from django.utils.translation import ugettext_lazy as _
 from askbot.conf.settings_wrapper import settings
 from askbot.conf.super_groups import REP_AND_BADGES
-from askbot.deps import livesettings
+from askbot.deps.livesettings import values as livesettings
 
 MIN_REP = livesettings.ConfigurationGroup(
     'MIN_REP',

--- a/askbot/conf/moderation.py
+++ b/askbot/conf/moderation.py
@@ -3,10 +3,10 @@
 from django.utils.translation import ugettext_lazy as _
 from askbot.conf.settings_wrapper import settings
 from askbot.conf.super_groups import DATA_AND_FORMATTING
-from askbot.deps.livesettings import ConfigurationGroup
-from askbot.deps.livesettings import BooleanValue
-from askbot.deps.livesettings import LongStringValue
-from askbot.deps.livesettings import StringValue
+from askbot.deps.livesettings.values import ConfigurationGroup
+from askbot.deps.livesettings.values import BooleanValue
+from askbot.deps.livesettings.values import LongStringValue
+from askbot.deps.livesettings.values import StringValue
 
 MODERATION = ConfigurationGroup(
     'MODERATION',

--- a/askbot/conf/question_lists.py
+++ b/askbot/conf/question_lists.py
@@ -4,7 +4,7 @@ Settings responsible for display of questions lists
 from django.utils.translation import ugettext_lazy as _
 from askbot.conf.settings_wrapper import settings
 from askbot.conf.super_groups import DATA_AND_FORMATTING
-from askbot.deps import livesettings
+from askbot.deps.livesettings import values as livesettings
 
 QUESTION_LISTS = livesettings.ConfigurationGroup(
     'QUESTION_LISTS',

--- a/askbot/conf/reputation_changes.py
+++ b/askbot/conf/reputation_changes.py
@@ -5,7 +5,7 @@ users or others
 """
 from django.utils.translation import ugettext_lazy as _
 from askbot.conf.settings_wrapper import settings
-from askbot.deps.livesettings import ConfigurationGroup, IntegerValue
+from askbot.deps.livesettings.values import ConfigurationGroup, IntegerValue
 from askbot.conf.super_groups import REP_AND_BADGES
 
 REP_CHANGES = ConfigurationGroup(

--- a/askbot/conf/settings_wrapper.py
+++ b/askbot/conf/settings_wrapper.py
@@ -32,7 +32,8 @@ from django.utils.translation import string_concat
 from django.utils.translation import ugettext_lazy as _
 
 import askbot
-from askbot.deps.livesettings import SortedDotDict, config_register
+from askbot.deps.livesettings.values import SortedDotDict
+from askbot.deps.livesettings.functions import config_register
 from askbot.deps.livesettings.functions import config_get
 from askbot.deps.livesettings import signals
 from askbot.utils.functions import format_setting_name
@@ -165,7 +166,7 @@ class ConfigSettings(object):
 
             required_links = map(lambda v: self.get_setting_url(v), required)
             optional_links = map(lambda v: self.get_setting_url(v), optional)
-                
+
             if required_links and optional_links:
                 return _(
                     'There are required related settings: '

--- a/askbot/conf/sidebar_main.py
+++ b/askbot/conf/sidebar_main.py
@@ -3,7 +3,7 @@ Sidebar settings
 """
 from django.utils.translation import ugettext_lazy as _
 from askbot.conf.settings_wrapper import settings
-from askbot.deps.livesettings import ConfigurationGroup
+from askbot.deps.livesettings.values import ConfigurationGroup
 from askbot.deps.livesettings import values
 from askbot.conf.super_groups import CONTENT_AND_UI
 

--- a/askbot/conf/sidebar_profile.py
+++ b/askbot/conf/sidebar_profile.py
@@ -3,7 +3,7 @@ Sidebar settings
 """
 from django.utils.translation import ugettext_lazy as _
 from askbot.conf.settings_wrapper import settings
-from askbot.deps.livesettings import ConfigurationGroup
+from askbot.deps.livesettings.values import ConfigurationGroup
 from askbot.deps.livesettings import values
 from askbot.conf.super_groups import CONTENT_AND_UI
 

--- a/askbot/conf/sidebar_question.py
+++ b/askbot/conf/sidebar_question.py
@@ -3,7 +3,7 @@ Sidebar settings
 """
 from django.utils.translation import ugettext_lazy as _
 from askbot.conf.settings_wrapper import settings
-from askbot.deps.livesettings import ConfigurationGroup
+from askbot.deps.livesettings.values import ConfigurationGroup
 from askbot.deps.livesettings import values
 from askbot.conf.super_groups import CONTENT_AND_UI
 

--- a/askbot/conf/site_modes.py
+++ b/askbot/conf/site_modes.py
@@ -7,8 +7,8 @@ Site modes settings:
 from django.utils.translation import ugettext_lazy as _
 from askbot.conf.settings_wrapper import settings
 from askbot.conf.super_groups import REP_AND_BADGES
-from askbot.deps.livesettings import ConfigurationGroup
-from askbot.deps.livesettings import BooleanValue
+from askbot.deps.livesettings.values import ConfigurationGroup
+from askbot.deps.livesettings.values import BooleanValue
 
 LARGE_SITE_MODE_SETTINGS = {
     # Minimum reputation settins.

--- a/askbot/conf/site_settings.py
+++ b/askbot/conf/site_settings.py
@@ -9,7 +9,7 @@ from django.conf import settings as django_settings
 
 from askbot.conf.settings_wrapper import settings
 from askbot.conf.super_groups import CONTENT_AND_UI
-from askbot.deps import livesettings
+from askbot.deps.livesettings import values as livesettings
 
 
 QA_SITE_SETTINGS = livesettings.ConfigurationGroup(

--- a/askbot/conf/skin_general_settings.py
+++ b/askbot/conf/skin_general_settings.py
@@ -8,7 +8,7 @@ from django.core.exceptions import ValidationError
 
 import askbot
 from askbot.conf.settings_wrapper import settings
-from askbot.deps.livesettings import ConfigurationGroup
+from askbot.deps.livesettings.values import ConfigurationGroup
 from askbot.deps.livesettings import values
 from askbot.skins import utils as skin_utils
 from askbot import const

--- a/askbot/conf/social_sharing.py
+++ b/askbot/conf/social_sharing.py
@@ -4,7 +4,7 @@ Social sharing settings
 from django.utils.translation import ugettext_lazy as _
 from askbot.conf.settings_wrapper import settings
 from askbot.conf.super_groups import EXTERNAL_SERVICES
-from askbot.deps.livesettings import ConfigurationGroup, BooleanValue, \
+from askbot.deps.livesettings.values import ConfigurationGroup, BooleanValue, \
     StringValue
 
 SOCIAL_SHARING = ConfigurationGroup(

--- a/askbot/conf/spam_and_moderation.py
+++ b/askbot/conf/spam_and_moderation.py
@@ -1,7 +1,7 @@
 """Settings for content moderation and spam control"""
 from django.utils.translation import ugettext_lazy as _
 from askbot import const
-from askbot.deps import livesettings
+from askbot.deps.livesettings import values as livesettings
 from askbot.conf.settings_wrapper import settings
 from askbot.conf.super_groups import EXTERNAL_SERVICES
 

--- a/askbot/conf/super_groups.py
+++ b/askbot/conf/super_groups.py
@@ -1,6 +1,6 @@
 from django.utils.translation import ugettext_lazy as _
-from askbot.deps.livesettings import SuperGroup
-from askbot.deps.livesettings import config_register_super_group
+from askbot.deps.livesettings.values import SuperGroup
+from askbot.deps.livesettings.functions import config_register_super_group
 
 REP_AND_BADGES = SuperGroup(_('Reputation, Badges, Votes & Flags'))
 CONTENT_AND_UI = SuperGroup(_('Static Content, URLS & UI'))

--- a/askbot/conf/user_settings.py
+++ b/askbot/conf/user_settings.py
@@ -3,7 +3,7 @@ User policy settings
 """
 from askbot.conf.settings_wrapper import settings
 from askbot.conf.super_groups import LOGIN_USERS_COMMUNICATION
-from askbot.deps import livesettings
+from askbot.deps.livesettings import values as livesettings
 from django.conf import settings as django_settings
 from askbot.skins import utils as skin_utils
 from django.utils.translation import ugettext_lazy as _
@@ -88,7 +88,7 @@ settings.register(
                  ('users', _('account owners and administrators'))),
         default='admins',
         description=_('Who can terminate user accounts')
-    ) 
+    )
 )
 
 settings.register(

--- a/askbot/conf/vote_rules.py
+++ b/askbot/conf/vote_rules.py
@@ -6,7 +6,7 @@ For example number of times a person can vote each day, etc.
 """
 from askbot.conf.settings_wrapper import settings
 from askbot.conf.super_groups import REP_AND_BADGES
-from askbot.deps.livesettings import ConfigurationGroup, IntegerValue
+from askbot.deps.livesettings.values import ConfigurationGroup, IntegerValue
 from django.utils.translation import ugettext_lazy as _
 
 VOTE_RULES = ConfigurationGroup(

--- a/askbot/conf/words.py
+++ b/askbot/conf/words.py
@@ -2,7 +2,7 @@
 General skin settings
 """
 from askbot.conf.settings_wrapper import settings
-from askbot.deps.livesettings import ConfigurationGroup
+from askbot.deps.livesettings.values import ConfigurationGroup
 from askbot.deps.livesettings import values
 from django.utils.translation import ugettext_lazy as _
 from askbot.skins import utils as skin_utils
@@ -130,7 +130,7 @@ settings.register(
 )
 
 #action definition (action def)
-#this phrase is used as a parameter within 
+#this phrase is used as a parameter within
 #another phrase like "sorry, you cannot ask questions"
 #hopefully it works, because it is used in indefinite form
 #other similarly used phrases are marked as "action def" below

--- a/askbot/deps/django_authopenid/views.py
+++ b/askbot/deps/django_authopenid/views.py
@@ -836,7 +836,7 @@ def show_signin_view(
         'login_form': login_form,
         'use_password_login': util.use_password_login(),
         'account_recovery_form': account_recovery_form,
-        'openid_error_message':  request.REQUEST.get('msg',''),
+        'openid_error_message':  request.GET.get('msg',request.POST.get('msg','')),
         'account_recovery_message': account_recovery_message,
         'use_password_login': util.use_password_login(),
     }
@@ -1266,7 +1266,7 @@ def verify_email_and_register(request):
     for GET - give a field to paste the activation code
     and a button to send another validation email.
     """
-    presented_code = request.REQUEST.get('validation_code', None)
+    presented_code = request.GET.get('validation_code',request.POST.get('validation_code',None))
     if presented_code:
         try:
             #we get here with post if button is pushed

--- a/askbot/deps/group_messaging/models.py
+++ b/askbot/deps/group_messaging/models.py
@@ -11,7 +11,10 @@ from django.db.models import signals
 from django.template import Context
 from django.template.loader import get_template
 from django.utils import timezone
-from django.utils.importlib import import_module
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
 from django.utils.translation import ugettext as _
 from askbot.deps.group_messaging.signals import response_created
 from askbot.deps.group_messaging.signals import thread_created

--- a/askbot/deps/group_messaging/tests.py
+++ b/askbot/deps/group_messaging/tests.py
@@ -88,7 +88,10 @@ class ViewsTests(GroupMessagingTests):
         assert(method in ('GET', 'POST'))
         spec.append(method)
         request = Mock(spec=spec)
-        request.REQUEST = data
+        if method == 'GET':
+            request.GET = data
+        else:
+            request.POST = data
         setattr(request, method, data)
         request.user = user
         return view_class().get_context(request)

--- a/askbot/deps/group_messaging/views.py
+++ b/askbot/deps/group_messaging/views.py
@@ -108,7 +108,7 @@ class ThreadsList(PjaxView):
             user = request.user
 
         #get threads and the last visit time
-        sender_id = IntegerField().clean(request.REQUEST.get('sender_id', '-1'))
+        sender_id = IntegerField().clean(request.GET.get('sender_id',request.POST.get('sender_id', '-1')))
 
         if sender_id == -2:
             received = Message.objects.get_threads(recipient=user, deleted=True)

--- a/askbot/deps/livesettings/__init__.py
+++ b/askbot/deps/livesettings/__init__.py
@@ -11,6 +11,6 @@ Inappropriate: The keyedcache timeout for the store.
 
 """
 
-from askbot.deps.livesettings.functions import *
-from askbot.deps.livesettings.models import *
-from askbot.deps.livesettings.values import *
+#from askbot.deps.livesettings.functions import *
+#from askbot.deps.livesettings.models import *
+#from askbot.deps.livesettings.values import *

--- a/askbot/deps/livesettings/forms.py
+++ b/askbot/deps/livesettings/forms.py
@@ -1,7 +1,7 @@
 import logging
 from django import forms
 from django.conf import settings as django_settings
-from askbot.deps.livesettings import ConfigurationGroup
+from askbot.deps.livesettings.values import ConfigurationGroup
 
 log = logging.getLogger('configuration')
 

--- a/askbot/deps/livesettings/models.py
+++ b/askbot/deps/livesettings/models.py
@@ -3,7 +3,7 @@ from askbot.deps.livesettings.overrides import get_overrides
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.db import models
-from django.db.models import loading
+from django.apps import apps as app_cache
 from django.utils.translation import ugettext_lazy
 from keyedcache import cache_key, cache_get, cache_set, NotCachedError
 from keyedcache.models import CachedObjectMixin
@@ -43,7 +43,7 @@ def find_setting(group, key, site=None):
         try:
             setting = cache_get(ck)
         except NotCachedError as nce:
-            if loading.app_cache_ready():
+            if app_cache.ready:
                 try:
                     setting = Setting.objects.get(site__id__exact=siteid, key__exact=key, group__exact=group)
 

--- a/askbot/deps/livesettings/templatetags/config_tags.py
+++ b/askbot/deps/livesettings/templatetags/config_tags.py
@@ -1,7 +1,7 @@
 from django import template
 from django.contrib.sites.models import Site
 from django.core import urlresolvers
-from askbot.deps.livesettings import config_value
+from askbot.deps.livesettings.functions import config_value
 from askbot.deps.livesettings.utils import url_join
 import logging
 

--- a/askbot/deps/livesettings/tests.py
+++ b/askbot/deps/livesettings/tests.py
@@ -1,7 +1,10 @@
 from django.conf import settings as djangosettings
 from django.test import TestCase
 import keyedcache
-from askbot.deps.livesettings import *
+from askbot.deps.livesettings.values import ConfigurationGroup, IntegerValue, StringValue, BooleanValue, ModuleValue, \
+                                            MultipleStringValue, LongStringValue
+from askbot.deps.livesettings.functions import config_exists, config_get, config_register, ConfigurationSettings, config_value
+from askbot.deps.livesettings.models import SettingNotSet, LongSetting
 import logging
 log = logging.getLogger('test');
 

--- a/askbot/deps/livesettings/values.py
+++ b/askbot/deps/livesettings/values.py
@@ -471,7 +471,7 @@ class Value(object):
                 log.error(e)
                 if str(e).find("configuration_setting") > -1:
                     if not _WARN.has_key('configuration_setting'):
-                        log.warn('Error loading setting %s.%s from table, OK if you are in syncdb', self.group.key, key)
+                        log.warn('Error loading setting %s.%s from table, OK if you are in migrate', self.group.key, key)
                         _WARN['configuration_setting'] = True
 
                     if self.use_default:

--- a/askbot/deps/livesettings/views.py
+++ b/askbot/deps/livesettings/views.py
@@ -7,8 +7,8 @@ from django.template import RequestContext
 from django.views.decorators.cache import never_cache
 from django.contrib import messages
 
-from askbot.deps.livesettings import ConfigurationSettings, forms
-from askbot.deps.livesettings import ImageValue
+from askbot.deps.livesettings.functions import ConfigurationSettings
+from askbot.deps.livesettings import forms
 from askbot.deps.livesettings.overrides import get_overrides
 from askbot.utils.decorators import admins_only
 

--- a/askbot/doc/source/import-data.rst
+++ b/askbot/doc/source/import-data.rst
@@ -14,7 +14,7 @@ StackExchange
 
 Add `askbot.importers.stackexchange` to the list of `INSTALLED_APPS` list in your `settings.py`, then run::
 
-    python manage.py syncdb
+    python manage.py migrate
 
 Then there will be two ways to import your StackExchange dump:
 
@@ -27,7 +27,7 @@ Then there will be two ways to import your StackExchange dump:
 Zendesk
 =======
 Add `askbot.importers.zendesk` to the list of `INSTALLED_APPS` in the `settings.py`,
-run `python manage.py syncdb`.
+run `python manage.py migrate`.
 
 Prepare your zendesk files: put all your .xml files into one directory and tar-zip it::
 

--- a/askbot/doc/source/initialize-database-tables.rst
+++ b/askbot/doc/source/initialize-database-tables.rst
@@ -6,7 +6,11 @@ Initialization and upgrade of the database for Askbot
 
 When you install Askbot the first time and any time you upgrade the software, run these two commands::
 
-    python manage.py syncdb
+    python manage.py migrate
+
+.. versionchanged:: 0.11.0-timewarp
+    syncdb has been removed from django 1.9. Must be replaced with migrate. `python manage.py syncdb` must now read
+    `python manage.py migrate`
 
 .. versionchanged:: 0.7.21
     When the script asks you if you want to create a superuser, answer yes if you want to create one. By default Askbot sets admin status(superuser) for the first user created automatically but also supports this form.
@@ -33,8 +37,8 @@ Now run the Django development server and check that everything works::
 
 .. note::
 
-    `hostname -i` is a Unix command returning the IP address of your system, you can also type 
-    the IP manually or replace it with word `localhost` if you are installing askbot 
+    `hostname -i` is a Unix command returning the IP address of your system, you can also type
+    the IP manually or replace it with word `localhost` if you are installing askbot
     on a local machine.
 
 Connect to the Django development server with your Web browser. The address is the name
@@ -52,7 +56,7 @@ This will be your administrator account.
 
 Here number 1 is the numeric id of the first user, enter a different number, if it is indeed different.
 
-Your basic installation is now complete. Many settings can be 
+Your basic installation is now complete. Many settings can be
 :ref:`changed at runtime <run-time-configuration>` by following url `/settings`.
 
 If you choose to host a real website, please read

--- a/askbot/doc/source/management-commands.rst
+++ b/askbot/doc/source/management-commands.rst
@@ -11,7 +11,7 @@ To run these commands there is a general pattern::
     cd project_directory
     python manage.py some_command [possible arguments and parameters]
 
-I.e. the commands are generally run from the project directory (the same 
+I.e. the commands are generally run from the project directory (the same
 one that contains your settings.py file) and they may use additional parameters and options.
 
 Data and User administration commands
@@ -117,7 +117,7 @@ These commands import or add data to the Askbot forum.
 |                                 | command on empty database. Also - before running, make sure |
 |                                 | that `askbot.importers.stackexchange` is in the list of     |
 |                                 | installed apps within your settings.py file (it might also  |
-|                                 | be necessary to run `syncdb` command to initiate the        |
+|                                 | be necessary to run `migrate` command to initiate the       |
 |                                 | SE importer tables).                                        |
 +---------------------------------+-------------------------------------------------------------+
 | `askbot_add_xml_content         | Add xml Askbot data dumped with the Django command          |
@@ -169,14 +169,14 @@ Any configurable options, related to these commands are accessible via "Email" s
 Data repair commands
 ====================
 
-Under certain circumstances (especially when using MySQL database with MyISAM 
-storage engine or when venturing to adapt the software to your needs) some 
-records in the database tables may become internally inconsistent. 
+Under certain circumstances (especially when using MySQL database with MyISAM
+storage engine or when venturing to adapt the software to your needs) some
+records in the database tables may become internally inconsistent.
 The commands from this section will help fix those issues.
 
 .. note::
 
- Data inconsistency in the Askbot project is considered as a critical error and as a matter of 
+ Data inconsistency in the Askbot project is considered as a critical error and as a matter of
  the project policy is addressed on the day of reporting. If you discover such issue - please
  report it at the forum or by email at `admin@askbot.org`
 
@@ -202,7 +202,7 @@ The commands from this section will help fix those issues.
 |                                          | the question cannot be found via the tag search.            |
 +------------------------------------------+-------------------------------------------------------------+
 
-The above commands are safe to run at any time, also they do not require 
+The above commands are safe to run at any time, also they do not require
 additional parameters. In the future all these will be replaced with just one simple command.
 
 Developer commands

--- a/askbot/doc/source/mysql-to-postgres.rst
+++ b/askbot/doc/source/mysql-to-postgres.rst
@@ -23,12 +23,12 @@ With MySQL as your database engine in your settings.py file run the following co
 
 After that change your database engine to Postgresql in settings.py and do::
 
-    python manage.py syncdb --migrate --noinput #create the database structure
+    python manage.py migrate --noinput #create the database structure
     python manage.py loaddata  data.json
 
 
 .. note::
-    This won't work with large datasets because django will load all your 
+    This won't work with large datasets because django will load all your
     data into memory and you might run out of memory if the site data is too large.
 
     This process can produce warnings that can be ignored.
@@ -42,22 +42,22 @@ If the database is large this tool will come handy, to install it run::
     pip install py-mysql2pgsql
 
 Create a configuration file called config.yml with the following contents::
-    
+
     mysql:
       hostname: localhost
       port: 3306
-      username: your_user 
-      password: your_password 
-      database: your_database 
+      username: your_user
+      password: your_password
+      database: your_database
 
     destination:
       file:
       postgres:
         hostname: localhost
         port: 5432
-        username: your_user 
-        password: your_password 
-        database: your_database 
+        username: your_user
+        password: your_password
+        database: your_database
 
 Then run::
 
@@ -70,7 +70,7 @@ After the process is finished there are a couple of things left to do.
 Enable Postgresql full text search
 ----------------------------------
 
-Askbot relies on special postgresql features for better search, in this case the py-mysql2pgsql tool will not 
+Askbot relies on special postgresql features for better search, in this case the py-mysql2pgsql tool will not
 add these features, so it requires to be added manually.
 
 To fix it run the command::
@@ -92,20 +92,20 @@ Test this by running a search query on the askbot site.
 Fixing data types
 -----------------
 
-The py-mysql2pgsql translates datatype a bit different than Django ORM do, to keep the same 
+The py-mysql2pgsql translates datatype a bit different than Django ORM do, to keep the same
 datatypes do the following:
 
 1. Create a new postgresql database and run sync and migrate commands the following way::
 
-    python manage.py syncdb --migrate --noinput --no-initial-data
+    python manage.py migrate --noinput --no-initial-data
 
 2. Dump the converted database data with binary format::
 
-    pg_dump --format=c -a database_name > dump_name 
+    pg_dump --format=c -a database_name > dump_name
 
 3. Restore it into your current Django database::
 
-    pg_restore -a --disable-triggers -d django_database dump_name 
+    pg_restore -a --disable-triggers -d django_database dump_name
 
 
 Links

--- a/askbot/importers/stackexchange/README
+++ b/askbot/importers/stackexchange/README
@@ -16,15 +16,15 @@ Current process to load SE data into Askbot is:
 
 3) enable 'stackexchange' in the list of installed apps (probably aready in settings.py)
 
-4) (optional - create models.py for SE, which is included anyway) run: 
+4) (optional - create models.py for SE, which is included anyway) run:
 
     #a) run in-place removal of xml namspace prefix to make parsing easier
-    perl -pi -w -e 's/xs://g' $SE_DUMP_PATH/xsd/*.xsd 
+    perl -pi -w -e 's/xs://g' $SE_DUMP_PATH/xsd/*.xsd
     cd stackexchange
     python parse_models.py $SE_DUMP_PATH/xsd/*.xsd > models.py
 
 5) Install stackexchange models (as well as any other missing models)
-    python manage.py syncdb
+    python manage.py migrate
 
 6) make sure that badges are installed
    if not, run (example for mysql):
@@ -45,12 +45,12 @@ Here is the load script that I used for the testing
 it assumes that SE dump has been unzipped inside the tmp directory
 
     #!/bin/sh$
-    python manage.py flush 
+    python manage.py flush
     #delete all data
     mysql -u askbot -p aksbot < sql_scripts/badges.sql
     python manage.py load_stackexchange tmp
 
-Untested parts are tagged with comments starting with 
+Untested parts are tagged with comments starting with
 #todo:
 
 The test set did not have all the usage cases of StackExchange represented so

--- a/askbot/importers/stackexchange/management/__init__.py
+++ b/askbot/importers/stackexchange/management/__init__.py
@@ -2,7 +2,7 @@ import logging
 import threading
 from django.core import management
 from django.core.exceptions import ImproperlyConfigured
-from django.db.models import get_model
+from django.apps import apps
 
 class ImporterThread(threading.Thread):
     def __init__(self, dump_file = None):
@@ -17,7 +17,7 @@ def is_ready():
     by trying to load a model from the database
     """
     try:
-        get_model('stackexchange', 'User2Vote')
+        apps.get_model('stackexchange', 'User2Vote')
         return True
     except Exception:
         return False

--- a/askbot/importers/stackexchange/management/commands/load_stackexchange.py
+++ b/askbot/importers/stackexchange/management/commands/load_stackexchange.py
@@ -332,7 +332,7 @@ it may be helpful to split this procedure in two:\n
         if not importer_is_ready():
             raise CommandError(
                 "Looks like stackexchange tables are not yet initialized in the database.\n"
-                "Please, run command: \npython manage.py syncdb\n"
+                "Please, run command: \npython manage.py migrate\n"
                 "then import the data."
             )
 

--- a/askbot/management/commands/export_osqa.py
+++ b/askbot/management/commands/export_osqa.py
@@ -59,7 +59,7 @@ class Command(BaseCommand):
             help="Use Django's base manager to dump all models stored in the database, including those that would otherwise be filtered or modified by a custom manager.")
 
     def handle(self, *app_labels, **options):
-        from django.db.models import get_app, get_apps, get_models, get_model
+        from django.apps import apps
 
         indent = options.get('indent', None)
         using = options.get('database', DEFAULT_DB_ALIAS)
@@ -74,31 +74,31 @@ class Command(BaseCommand):
         for exclude in excludes:
             if '.' in exclude:
                 app_label, model_name = exclude.split('.', 1)
-                model_obj = get_model(app_label, model_name)
+                model_obj = apps.get_model(app_label, model_name)
                 if not model_obj:
                     raise CommandError('Unknown model in excludes: %s' % exclude)
                 excluded_models.add(model_obj)
             else:
                 try:
-                    app_obj = get_app(exclude)
+                    app_obj = apps.get_app(exclude)
                     excluded_apps.add(app_obj)
                 except ImproperlyConfigured:
                     raise CommandError('Unknown app in excludes: %s' % exclude)
 
         if len(app_labels) == 0:
-            app_list = OrderedDict((app, None) for app in get_apps() if app not in excluded_apps)
+            app_list = OrderedDict((app, None) for app in apps.get_apps() if app not in excluded_apps)
         else:
             app_list = OrderedDict()
             for label in app_labels:
                 try:
                     app_label, model_label = label.split('.')
                     try:
-                        app = get_app(app_label)
+                        app = apps.get_app(app_label)
                     except ImproperlyConfigured:
                         raise CommandError("Unknown application: %s" % app_label)
                     if app in excluded_apps:
                         continue
-                    model = get_model(app_label, model_label)
+                    model = apps.get_model(app_label, model_label)
                     if model is None:
                         raise CommandError("Unknown model: %s.%s" % (app_label, model_label))
 
@@ -111,7 +111,7 @@ class Command(BaseCommand):
                     # This is just an app - no model qualifier
                     app_label = label
                     try:
-                        app = get_app(app_label)
+                        app = apps.get_app(app_label)
                     except ImproperlyConfigured:
                         raise CommandError("Unknown application: %s" % app_label)
                     if app in excluded_apps:
@@ -144,13 +144,13 @@ def sort_dependencies(app_list):
     is serialized before a normal model, and any model with a natural key
     dependency has it's dependencies serialized first.
     """
-    from django.db.models import get_model, get_models
+    from django.apps import apps
     # Process the list of models, and get the list of dependencies
     model_dependencies = []
     models = set()
     for app, model_list in app_list:
         if model_list is None:
-            model_list = get_models(app)
+            model_list = apps.get_models(app)
 
         for model in model_list:
             models.add(model)
@@ -158,7 +158,7 @@ def sort_dependencies(app_list):
             if hasattr(model, 'natural_key'):
                 deps = getattr(model.natural_key, 'dependencies', [])
                 if deps:
-                    deps = [get_model(*d.split('.')) for d in deps]
+                    deps = [apps.get_model(*d.split('.')) for d in deps]
             else:
                 deps = []
 

--- a/askbot/management/commands/export_osqa.py
+++ b/askbot/management/commands/export_osqa.py
@@ -16,7 +16,7 @@ class XMLExportSerializer(Serializer):
 
         self.stream = options.pop("stream", StringIO())
         self.selected_fields = options.pop("fields", None)
-        self.use_natural_keys = options.pop("use_natural_keys", False)
+        self.use_natural_foreign_keys = options.pop("use_natural_foreign_keys", False)
 
         self.start_serialization()
         for obj in queryset:
@@ -53,7 +53,7 @@ class Command(BaseCommand):
                 'fixtures into. Defaults to the "default" database.')
         parser.add_argument('-e', '--exclude', dest='exclude',action='append', default=['sessions', 'contenttypes'],
             help='An appname or appname.ModelName to exclude (use multiple --exclude to exclude multiple apps/models).')
-        parser.add_argument('-n', '--natural', action='store_true', dest='use_natural_keys', default=False,
+        parser.add_argument('--natural-foreign', action='store_true', dest='use_natural_foreign_keys', default=False,
             help='Use natural keys if they are available.')
         parser.add_argument('-a', '--all', action='store_true', dest='use_base_manager', default=False,
             help="Use Django's base manager to dump all models stored in the database, including those that would otherwise be filtered or modified by a custom manager.")
@@ -66,7 +66,7 @@ class Command(BaseCommand):
         connection = connections[using]
         excludes = options.get('exclude',[])
         show_traceback = options.get('traceback', False)
-        use_natural_keys = options.get('use_natural_keys', False)
+        use_natural_foreign_keys = options.get('use_natural_foreign_keys', False)
         use_base_manager = options.get('use_base_manager', False)
 
         excluded_apps = set()
@@ -131,7 +131,7 @@ class Command(BaseCommand):
 
         try:
             serializer = XMLExportSerializer()
-            return serializer.serialize(objects, indent=indent, use_natural_keys=use_natural_keys)
+            return serializer.serialize(objects, indent=indent, use_natural_foreign_keys=use_natural_foreign_keys)
         except Exception as e:
             if show_traceback:
                 raise

--- a/askbot/management/commands/export_osqa.py
+++ b/askbot/management/commands/export_osqa.py
@@ -123,7 +123,7 @@ class Command(BaseCommand):
         for model in sort_dependencies(app_list.items()):
             if model in excluded_models:
                 continue
-            if not model._meta.proxy and router.allow_syncdb(using, model):
+            if not model._meta.proxy and router.allow_migrate(using, model):
                 if use_base_manager:
                     objects.extend(model._base_manager.using(using).all())
                 else:

--- a/askbot/middleware/cancel.py
+++ b/askbot/middleware/cancel.py
@@ -2,7 +2,7 @@ from django.http import HttpResponseRedirect
 from askbot.utils.forms import get_next_url
 class CancelActionMiddleware(object):
     def process_view(self, request, view_func, view_args, view_kwargs):
-        if 'cancel' in request.REQUEST:
+        if 'cancel' in request.GET or 'cancel' in request.POST:
             #todo use session messages for the anonymous users
             try:
                 msg = getattr(view_func,'CANCEL_MESSAGE')

--- a/askbot/models/__init__.py
+++ b/askbot/models/__init__.py
@@ -27,7 +27,6 @@ from django.utils.translation import ugettext as _
 from django.utils.translation import string_concat, override, ungettext
 from django.utils.safestring import mark_safe
 from django.utils.html import escape
-from django.db import models
 from django.db.models import Count, Q
 from django.conf import settings as django_settings
 from django.contrib.contenttypes.models import ContentType

--- a/askbot/models/repute.py
+++ b/askbot/models/repute.py
@@ -1,7 +1,7 @@
 import datetime
 
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.contenttypes import generic
+from django.contrib.contenttypes import fields
 from django.contrib.auth.models import User
 from django.db import models
 from django.utils.translation import ugettext as _
@@ -154,7 +154,7 @@ class Award(models.Model):
     badge = models.ForeignKey(BadgeData, related_name='award_badge')
     content_type = models.ForeignKey(ContentType)
     object_id = models.PositiveIntegerField()
-    content_object = generic.GenericForeignKey('content_type', 'object_id')
+    content_object = fields.GenericForeignKey('content_type', 'object_id')
     awarded_at = models.DateTimeField(default=timezone.now)
     notified = models.BooleanField(default=False)
 

--- a/askbot/models/user.py
+++ b/askbot/models/user.py
@@ -5,7 +5,7 @@ from django.db import models
 from django.db.models import Q
 from django.db.backends.dummy.base import IntegrityError
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.contenttypes import generic
+from django.contrib.contenttypes import fields
 from django.contrib.auth.models import User
 from django.contrib.auth.models import Group as AuthGroup
 from django.core import exceptions
@@ -302,7 +302,7 @@ class Activity(models.Model):
     active_at = models.DateTimeField(default=timezone.now)
     content_type = models.ForeignKey(ContentType)
     object_id = models.PositiveIntegerField(db_index=True)
-    content_object = generic.GenericForeignKey('content_type', 'object_id')
+    content_object = fields.GenericForeignKey('content_type', 'object_id')
 
     #todo: remove this denorm question field when Post model is set up
     question = models.ForeignKey('Post', null=True)

--- a/askbot/patches/django_patches.py
+++ b/askbot/patches/django_patches.py
@@ -281,7 +281,10 @@ def add_import_library_function():
 
     #this definition is copy/pasted from django 1.2 source code
     #it is necessary to make Coffin library happy
-    from django.utils.importlib import import_module
+    try:
+        from importlib import import_module
+    except ImportError:
+        from django.utils.importlib import import_module
     class InvalidTemplateLibrary(Exception):
         pass
 

--- a/askbot/search/haystack/indexes.py
+++ b/askbot/search/haystack/indexes.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.conf import settings
-from django.db.models import get_model
+from django.apps import apps
 
 from haystack import indexes
 
@@ -19,7 +19,7 @@ class ThreadIndex(get_base_index()):
         return obj.language_code
 
     def get_model(self):
-        return get_model('askbot', 'Thread')
+        return apps.get_model('askbot', 'Thread')
 
     def get_index_kwargs(self, language):
         kwargs = {'deleted': False}
@@ -41,4 +41,4 @@ class UserIndex(get_base_index()):
     haystack_use_for_indexing = ENABLE_HAYSTACK_SEARCH
 
     def get_model(self):
-        return get_model('auth', 'User')
+        return apps.get_model('auth', 'User')

--- a/askbot/search/haystack/utils.py
+++ b/askbot/search/haystack/utils.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings
-from django.utils.importlib import import_module
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
 from django.utils.translation import get_language as _get_language
 
 from haystack.constants import DEFAULT_ALIAS

--- a/askbot/setup_templates/settings.py.mustache
+++ b/askbot/setup_templates/settings.py.mustache
@@ -29,8 +29,10 @@ DATABASES = {
         'PASSWORD': '{{database_password}}',                  # Not used with sqlite3.
         'HOST': '{{database_host}}',                      # Set to empty string for localhost. Not used with sqlite3.
         'PORT': '{{database_port}}',                      # Set to empty string for default. Not used with sqlite3.
-        'TEST_CHARSET': 'utf8',              # Setting the character set and collation to utf-8
-        'TEST_COLLATION': 'utf8_general_ci', # is necessary for MySQL tests to work properly.
+        'TEST': {
+            'CHARSET': 'utf8',              # Setting the character set and collation to utf-8
+            'COLLATION': 'utf8_general_ci', # is necessary for MySQL tests to work properly.
+        }
     }
 }
 

--- a/askbot/signals.py
+++ b/askbot/signals.py
@@ -5,7 +5,7 @@ from collections import namedtuple
 import django.dispatch
 
 from django.db.models.signals import (pre_save, post_save,
-                                      pre_delete, post_delete, post_syncdb)
+                                      pre_delete, post_delete, post_migrate)
 
 try:
     from django.db.models.signals import m2m_changed
@@ -99,7 +99,7 @@ def pop_all_db_signal_receivers():
         post_save,
         pre_delete,
         post_delete,
-        post_syncdb,
+        post_migrate,
         question_visited,
     )
     if 'm2m_changed' in globals():

--- a/askbot/skins/loaders.py
+++ b/askbot/skins/loaders.py
@@ -86,7 +86,10 @@ class AppDirectoryEnvironment(MultilingualEnvironment):
         """returns path to directory `templates` within the app directory
         """
         assert(app_name in django_settings.INSTALLED_APPS)
-        from django.utils.importlib import import_module
+        try:
+            from importlib import import_module
+        except ImportError:
+            from django.utils.importlib import import_module
         try:
             mod = import_module(app_name)
         except ImportError as e:

--- a/askbot/templates/import_data.html
+++ b/askbot/templates/import_data.html
@@ -3,10 +3,10 @@
 {% block content %}
     <h1>{% trans %}Import StackExchange data{% endtrans %}</h1>
     {% if need_configuration %}
-        <p><em>Note:</em> to import stackexchange data, first add 
+        <p><em>Note:</em> to import stackexchange data, first add
             <code>'askbot.importers.stackexchange',</code>
             to the <code>INSTALLED_APPS</code> setting in your <code>settings.py</code>
-            file, then run <code>python manage.py syncdb</code>, and restart the application.
+            file, then run <code>python manage.py migrate</code>, and restart the application.
             After that, pleale return to here and try again.
         </p>
     {% else %}

--- a/askbot/tests/test_user_views.py
+++ b/askbot/tests/test_user_views.py
@@ -14,9 +14,10 @@ class UserViewsTests(AskbotTestCase):
         def mock_view(request, user, context):
             return None
 
-        request = Mock(spec=('path', 'REQUEST', 'user'))
+        request = Mock(spec=('path', 'POST', 'user', 'method'))
+        request.method = "POST"
         request.user = AnonymousUser()
-        request.REQUEST = {'abra': 'cadabra', 'foo': 'bar'}
+        request.POST = {'abra': 'cadabra', 'foo': 'bar'}
         request.path = '/some/path/'
         user = self.create_user('user')
         response = mock_view(request, user, {})

--- a/askbot/utils/forms.py
+++ b/askbot/utils/forms.py
@@ -1,5 +1,6 @@
 import re
 from django import forms
+from django.apps import apps
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from django.http import Http404
@@ -42,7 +43,7 @@ def get_db_object_or_404(params):
     try:
         model_name = params['model_name']
         assert(model_name=='Group')
-        model = models.get_model(model_name)
+        model = apps.get_model('askbot', model_name)
         obj_id = forms.IntegerField().clean(params['object_id'])
         return get_object_or_404(model, id=obj_id)
     except Exception:

--- a/askbot/utils/forms.py
+++ b/askbot/utils/forms.py
@@ -30,7 +30,7 @@ def get_error_list(form_instance):
     return errors
 
 def get_next_url(request, default=None):
-    return clean_next(request.REQUEST.get('next'), default)
+    return clean_next(request.GET.get('next',request.POST.get('next', default)))
 
 def get_db_object_or_404(params):
     """a utility function that returns an object

--- a/askbot/utils/loading.py
+++ b/askbot/utils/loading.py
@@ -7,10 +7,8 @@ def load_module(mod_path):
     import module
 
     TODO: is this the same as the following?
-    try:
-        from django.utils.module_loading import import_string
-    except ImportError:
-        from django.utils.module_loading import import_by_path as import_string
+    from importlib import import_module
+    import_module(mod_path)?
     """
     assert(mod_path[0] != '.')
     path_bits = mod_path.split('.')

--- a/askbot/views/commands.py
+++ b/askbot/views/commands.py
@@ -269,7 +269,7 @@ def mark_tag(request, **kwargs):#tagging system
 def clean_tag_name(request):
     tag_name = forms.clean_tag(request.POST['tag_name'])
     return {'cleaned_tag_name': tag_name}
-    
+
 
 #@decorators.ajax_only
 @decorators.get_only
@@ -324,7 +324,7 @@ def get_thread_shared_groups(request):
 @decorators.ajax_only
 def get_html_template(request):
     """returns rendered template"""
-    template_name = request.REQUEST.get('template_name', None)
+    template_name = getattr(request,request.method).get('template_name', None)
     allowed_templates = (
         'widgets/tag_category_selector.html',
     )
@@ -479,7 +479,7 @@ def get_groups_list(request):
 def subscribe_for_tags(request):
     """process subscription of users by tags"""
     #todo - use special separator to split tags
-    tag_names = request.REQUEST.get('tags','').strip().split()
+    tag_names = getattr(request,request.method).get('tags','').strip().split()
     pure_tag_names, wildcards = forms.clean_marked_tagnames(tag_names)
     if request.user.is_authenticated():
         if request.method == 'POST':
@@ -496,7 +496,7 @@ def subscribe_for_tags(request):
             else:
                 message = _(
                     'Tag subscription was canceled (<a href="%(url)s">undo</a>).'
-                ) % {'url': escape(request.path) + '?tags=' + request.REQUEST['tags']}
+                ) % {'url': escape(request.path) + '?tags=' + getattr(request,request.method)['tags']}
                 request.user.message_set.create(message = message)
             return HttpResponseRedirect(reverse('index'))
         else:
@@ -1015,9 +1015,9 @@ def set_group_openness(request):
 @decorators.ajax_only
 @decorators.moderators_only
 def edit_object_property_text(request):
-    model_name = CharField().clean(request.REQUEST['model_name'])
-    object_id = IntegerField().clean(request.REQUEST['object_id'])
-    property_name = CharField().clean(request.REQUEST['property_name'])
+    model_name = CharField().clean(getattr(request,request.method)['model_name'])
+    object_id = IntegerField().clean(getattr(request,request.method)['object_id'])
+    property_name = CharField().clean(getattr(request,request.method)['property_name'])
 
     accessible_fields = (
         ('Group', 'preapproved_emails'),

--- a/askbot/views/readers.py
+++ b/askbot/views/readers.py
@@ -308,7 +308,7 @@ def get_top_answers(request):
 
 def tags(request):#view showing a listing of available tags - plain list
 
-    form = ShowTagsForm(request.REQUEST)
+    form = ShowTagsForm(getattr(request,request.method))
     form.full_clean() #always valid
     page = form.cleaned_data['page']
     sort_method = form.cleaned_data['sort']
@@ -390,7 +390,7 @@ def question(request, id):#refactor - long subroutine. display question body, an
     #process url parameters
     #todo: fix inheritance of sort method from questions
     #before = timezone.now()
-    form = ShowQuestionForm(request.REQUEST)
+    form = ShowQuestionForm(getattr(request,request.method))
     form.full_clean()#always valid
     show_answer = form.cleaned_data['show_answer']
     show_comment = form.cleaned_data['show_comment']

--- a/askbot/views/users.py
+++ b/askbot/views/users.py
@@ -78,7 +78,7 @@ def owner_or_moderator_required(f):
                 #as this one should be accessible to all
                 return HttpResponseRedirect(request.path)
         else:
-            next_url = request.path + '?' + urllib.urlencode(request.REQUEST)
+            next_url = request.path + '?' + urllib.urlencode(getattr(request,request.method))
             params = '?next=%s' % urllib.quote(next_url)
             return HttpResponseRedirect(url_utils.get_login_url() + params)
         return f(request, profile_owner, context)
@@ -184,7 +184,7 @@ def show_users(request, by_group=False, group_id=None, group_slug=None):
 
     is_paginated = True
 
-    form = forms.ShowUsersForm(request.REQUEST)
+    form = forms.ShowUsersForm(getattr(request,request.method))
     form.full_clean()#always valid
     sort_method = form.cleaned_data['sort']
     page = form.cleaned_data['page']
@@ -873,7 +873,7 @@ def user_recent(request, user, context):
                 # don't know what to do here...
                 event_title = ''
                 event_summary = ''
-                
+
             event = Event(
                 time=activity.active_at,
                 type=activity.activity_type,
@@ -1127,7 +1127,7 @@ def user_reputation(request, user, context):
                                         'question__thread',
                                         'user'
                                     )
-                                    
+
 
     def format_graph_data(raw_data, user):
         # prepare data for the graph - last values go in first
@@ -1272,7 +1272,7 @@ def user_select_languages(request, id=None, slug=None):
 
 @csrf.csrf_protect
 def user_unsubscribe(request):
-    form = forms.UnsubscribeForm(request.REQUEST)
+    form = forms.UnsubscribeForm(getattr(request,request.method))
     verified_email = ''
     if form.is_valid() == False:
         result = 'bad_input'
@@ -1431,7 +1431,7 @@ def user(request, id, slug=None, tab_name=None):
 
     if slugify(profile_owner.username) != slug:
         view_url = profile_owner.get_profile_url() + '?' \
-                                + urllib.urlencode(request.REQUEST)
+                                + urllib.urlencode(getattr(request,request.method))
         return HttpResponseRedirect(view_url)
 
     if not tab_name:

--- a/askbot/views/writers.py
+++ b/askbot/views/writers.py
@@ -300,15 +300,15 @@ def ask(request):#view used to ask a new question
             draft_tagnames = draft.tagnames
 
     form.initial = {
-        'ask_anonymously': request.REQUEST.get('ask_anonymously', False),
-        'tags': request.REQUEST.get('tags', draft_tagnames),
-        'text': request.REQUEST.get('text', draft_text),
-        'title': request.REQUEST.get('title', draft_title),
-        'post_privately': request.REQUEST.get('post_privately', False),
+        'ask_anonymously': getattr(request,request.method).get('ask_anonymously', False),
+        'tags': getattr(request,request.method).get('tags', draft_tagnames),
+        'text': getattr(request,request.method).get('text', draft_text),
+        'title': getattr(request,request.method).get('title', draft_title),
+        'post_privately': getattr(request,request.method).get('post_privately', False),
         'language': get_language(),
-        'wiki': request.REQUEST.get('wiki', False),
+        'wiki': getattr(request,request.method).get('wiki', False),
     }
-    if 'group_id' in request.REQUEST:
+    if 'group_id' in getattr(request,request.method):
         try:
             group_id = int(request.GET.get('group_id', None))
             form.initial['group_id'] = group_id
@@ -757,7 +757,7 @@ def post_comments(request):#generic ajax handler to load comments to an object
     add a new comment to post
     """
     # only support get post comments by ajax now
-    post_type = request.REQUEST.get('post_type', '')
+    post_type = getattr(request,request.method).get('post_type', '')
     if not request.is_ajax() or post_type not in ('question', 'answer'):
         raise Http404  # TODO: Shouldn't be 404! More like 400, 403 or sth more specific
 

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ Create/update database tables
 
 Back up your database if it is not blank, then two commands:
 
-* python manage.py syncdb
+* python manage.py migrate
 * python manage.py migrate
 
 There are two apps to migrate - askbot and django_authopenid (a forked version of the original, included within askbot), so you can as well migrate them separately

--- a/testproject/testproject/settings.py
+++ b/testproject/testproject/settings.py
@@ -24,10 +24,10 @@ ADMINS = (
 MANAGERS = ADMINS
 
 DATABASE = dj_database_url.config(default='sqlite:///db.data')
-DATABASE.update({
-    'TEST_CHARSET': 'utf8',              # Setting the character set and collation to utf-8
-    'TEST_COLLATION': 'utf8_general_ci', # is necessary for MySQL tests to work properly.
-})
+DATABASE.update({ 'TEST': {
+    'CHARSET': 'utf8',              # Setting the character set and collation to utf-8
+    'COLLATION': 'utf8_general_ci', # is necessary for MySQL tests to work properly.
+}})
 DATABASES = {'default': DATABASE}
 
 #outgoing mail server settings

--- a/testproject/testproject/settings.py
+++ b/testproject/testproject/settings.py
@@ -310,7 +310,7 @@ COMPRESS_PARSER = 'compressor.parser.HtmlParser'
 JINJA2_EXTENSIONS = ('compressor.contrib.jinja2ext.CompressorExtension',)
 JINJA2_TEMPLATES = ('captcha',)
 
-# Use syncdb for tests instead of South migrations. Without this, some tests
+# Use migrate for tests instead of South migrations. Without this, some tests
 # fail spuriously in MySQL.
 SOUTH_TESTS_MIGRATE = False
 


### PR DESCRIPTION
Django 1.7 deprecated a lot of things which were scheduled for removal in Django 1.9. I worked through the Django release notes and changed the Askbot code where necessary to get rid of deprecated APIs.

The test suite completes successfully with these changes applied to master. Only tested with Django 1.8 but since these new API were introduced at <=1.7, this should work with 1.7 as well