### PR TITLE
Do not imply that the docker image will be run with postgres

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 #
 # Start with something like
 #
-# docker run -e 'DATABASE_URL=sqlite:////askbot_site/askbot.db' -e "SECRET_KEY=$(openssl rand 14 | base64)" -e ADMIN_PASSWORD=admin -p 8080:80 askbot/askbot:latest
+# docker run -e 'DATABASE_URL=sqlite:////askbot-site/askbot.db' -e "SECRET_KEY=$(openssl rand 14 | base64)" -e ADMIN_PASSWORD=admin -p 8080:80 askbot/askbot:latest
 #
 # User uploads are stored in **/askbot_site/askbot/upfiles** . I'd recommend to make it a kubernetes volume.
 

--- a/askbot/container/prestart.py
+++ b/askbot/container/prestart.py
@@ -20,10 +20,10 @@ do_admin      = True
 do_make_admin = True
 do_uwsgi_ini  = True
 
-import psycopg2
 from time import sleep
 
-if dsn is not None:
+if dsn is not None and dsn.startswith('postgres'):
+    import psycopg2
     print(f'Waiting for database {dsn}')
     for retry in range(1,10):
         try:


### PR DESCRIPTION
* prestart.py would just go ahead and try to connect to a postgres DB.
  When there isn't a Postgres DB this will yield an error
* Fixed example docker run command to prevent copy/paste frustration