### PR TITLE
Make Askbot flexible again

### DIFF
--- a/askbot/deps/django_authopenid/util.py
+++ b/askbot/deps/django_authopenid/util.py
@@ -379,7 +379,7 @@ def add_custom_provider(func):
             mod = LoginMethod(login_module_path)
             if mod.is_major != func.is_major:
                 return providers#only patch the matching provider set
-            providers.insert(mod.order_number - 1, mod.name, mod.as_dict())
+            providers['mod.name'] = mod.as_dict()
         return providers
     return wrapper
 

--- a/askbot/setup_templates/settings.py.jinja2
+++ b/askbot/setup_templates/settings.py.jinja2
@@ -85,7 +85,7 @@ ASKBOT_LANGUAGE_MODE = 'single-lang' #'single-lang', 'url-lang', 'user-lang'
 # Absolute path to the directory that holds uploaded media
 # Example: "/home/media/media.lawrence.com/"
 MEDIA_ROOT = os.path.join(os.path.dirname(__file__), 'askbot', 'upfiles')
-MEDIA_URL = '/upfiles/'#url to uploaded media
+MEDIA_URL = '/upfiles/' # url to uploaded media. This is expected to start with a /
 STATIC_URL = '/m/'#this must be different from MEDIA_URL
 USE_LOCAL_FONTS = False
 


### PR DESCRIPTION
`OrderedDict` does not have a method `insert` (anymore?). However, a call to it is in the code that adds an authentication provider to `django_authopenid` through the app's `settings.py`. Having applied the first patch I was able to add a local OAuth2 provider without (further) touching the code of `django_authopenid`.

The second patch makes Jinja2 look for templates in a skin's directory. If I understand Jinja2's internals correctly, it first searches for a template in the skin dir and then its other dirs. Skins should now be able to replace individual template files. For my test setup I chose a value for `ASKBOT_EXTRA_SKINS_DIR` (i.e., an absolute path) that ends with `themes`. The layout of my test skin `mySkin` then looks like this:

    themes/
    themes/mySkin
    themes/mySkin/jinja2
    themes/mySkin/jinja2/base.html
    themes/mySkin/media
    themes/mySkin/media/style
    themes/mySkin/media/style/style.css
    themes/mySkin/media/images
    themes/mySkin/media/images/nophoto.png

With my webbrowser I was able to confirm that Askbot did indeed use `base.html`, `style.css` and `nophoto.png` from `themes/mySkin`.
