### PR TITLE
Bugfix! Variable was not resolved but used literally.

### DIFF
--- a/askbot/deps/django_authopenid/util.py
+++ b/askbot/deps/django_authopenid/util.py
@@ -379,7 +379,7 @@ def add_custom_provider(func):
             mod = LoginMethod(login_module_path)
             if mod.is_major != func.is_major:
                 return providers#only patch the matching provider set
-            providers['mod.name'] = mod.as_dict()
+            providers[mod.name] = mod.as_dict()
         return providers
     return wrapper
 


### PR DESCRIPTION
The last patch introduced a bug where too many `'` are involved.

    providers['mod.name']

should be

    providers[mod.name]