### PR TITLE
Django_autopenid provide missing param on create_user

### DIFF
--- a/askbot/deps/django_authopenid/views.py
+++ b/askbot/deps/django_authopenid/views.py
@@ -516,7 +516,7 @@ def signin(request, template_name='authopenid/signin.html'):
                         if user_info['success']:
                             if askbot_settings.LDAP_AUTOCREATE_USERS:
                                 #create new user or
-                                user = ldap_create_user(user_info).user
+                                user = ldap_create_user(user_info, request).user
                                 user = authenticate(method='force', user_id=user.pk)
                                 assert(user is not None)
                                 login(request, user)
@@ -1195,7 +1195,7 @@ def register(request, login_provider_name=None,
                 #they can override the default provided by LDAP
                 user_info['django_username'] = username
                 user_info['email'] = email
-                user = ldap_create_user(user_info).user
+                user = ldap_create_user(user_info, request).user
                 user = authenticate(user_id=user.id, method='force')
                 del request.session['ldap_user_info']
                 login(request, user)


### PR DESCRIPTION
! ldap_create_user had been updated to take a second param of the
request. Usages in django_authopenid/views.py were not taking this
change into account