### PR TITLE
using OneToOneField

### DIFF
--- a/askbot/deps/django_authopenid/models.py
+++ b/askbot/deps/django_authopenid/models.py
@@ -86,7 +86,7 @@ class UserPasswordQueue(models.Model):
     """
     model for new password queue.
     """
-    user = models.ForeignKey(User, unique=True)
+    user = models.OneToOneField(User)
     new_password = models.CharField(max_length=30)
     confirm_key = models.CharField(max_length=40)
 


### PR DESCRIPTION
Because Foreign key implicitly means unique = True.

Django suggests using models.OneToOneField

django_authopenid.UserPasswordQueue.user: (fields.W342) Setting unique=True on a ForeignKey has the same effect as using a OneToOneField.
    HINT: ForeignKey(unique=True) is usually better served by a OneToOneField.