### PR TITLE
Set last activity when accepting answer

### DIFF
--- a/askbot/models/question.py
+++ b/askbot/models/question.py
@@ -912,6 +912,7 @@ class Thread(models.Model):
             raise ValueError("Answer doesn't belong to this thread")
         # TODO: in the future there may be >1 accepted answer
         self.accepted_answer = answer
+        self.set_last_activity_info(timestamp, actor)
         self.save()
         answer.endorsed = True
         answer.endorsed_at = timestamp


### PR DESCRIPTION
I believe this is a bug that is affecting my API endpoint. 
 * [Here is an example question](https://answers.ros.org/api/v1/questions/308141/) that I recently marked as having an accepted answer. Note that `last_activity_at=1557194036`
 * [Here is the accepted answer](https://answers.ros.org/api/v1/answers/322574/) which was `added_at=1557194036` (which is the same as the last activity)

This means that my action of accepting the answer is not reflected in the `last_activity_at` timestamp, which makes it difficult to keep track of which questions don't have accepted answers. 

I believe this PR should fix it, but I'm not 100% certain and haven't tested it locally yet. 


