### PR TITLE
Fix year 2020 displaying as '0 instead of '20

### DIFF
--- a/askbot/media/jslib/timeago.js
+++ b/askbot/media/jslib/timeago.js
@@ -107,7 +107,7 @@
             //how to do this in js???
             return month_date;
         } else {
-            return month_date + ' ' + "'" + date.getYear() % 20;
+            return month_date + ' ' + "'" + date.getYear() % 100;
         }
     } else if (days == 2) {
         return gettext('2 days ago')


### PR DESCRIPTION
Following the report by @embray and the analysis by @rburing at

- Ask Sage question 49411: https://ask.sagemath.org/question/49411

Fixes #862.

