### PR TITLE
Fix askbot only showing '0 years ago'

### DIFF
--- a/askbot/media/jslib/timeago.js
+++ b/askbot/media/jslib/timeago.js
@@ -88,11 +88,11 @@
 
     function inWords(date) {
         var distanceMillis = distance(date);
-        var seconds = Math.abs(distanceMillis) / 1000;
-        var minutes = seconds / 60;
-        var hours = minutes / 60;
-        var days = hours / 24;
-        var years = days / 365;
+        var seconds = Math.floor(Math.abs(distanceMillis) / 1000);
+        var minutes = Math.floor(seconds / 60);
+        var hours = Math.floor(minutes / 60);
+        var days = Math.floor(hours / 24);
+        var years = Math.floor(days / 365);
         var months = [
             gettext("Jan"),
             gettext("Feb"),


### PR DESCRIPTION
I have no idea if it is just my browser / browser-version, but for me, the way it was before only showed '0 years ago' everywhere (except where it was 1...) A user reported the same after I updated askbot to the newest version. This fixed it. 