### PR TITLE
fix --db-engine option in askbot-setup

### DIFF
--- a/askbot/deployment/__init__.py
+++ b/askbot/deployment/__init__.py
@@ -235,7 +235,6 @@ class AskbotSetup:
             dest='database_engine',
             action='store',
             choices=[eng[0] for eng in const.DATABASE_ENGINE_CHOICES],
-            type=int,
             help=const.DATABASE_ENGINE_HELP
         )
 


### PR DESCRIPTION
the code expects the option to be a string, but the cli parser had a validation checking whether it was an integer

closes #884
closes #891 