### PR TITLE
Fix error when user has custom avatar

### DIFF
--- a/askbot/models/__init__.py
+++ b/askbot/models/__init__.py
@@ -313,7 +313,7 @@ def user_calculate_avatar_url(self, size=48):
             from avatar.util import get_primary_avatar
             logging.warning("Using deprecated version of django-avatar")
 
-        avatar = get_primary_avatar(self, size=size)
+        avatar = get_primary_avatar(self, width=size, height=size)
         if avatar:
             return avatar.avatar_url(size)
         return self.get_default_avatar_url(size)

--- a/askbot_requirements.txt
+++ b/askbot_requirements.txt
@@ -6,7 +6,7 @@ beautifulsoup4<=4.7.1
 bleach==5.0.1
 celery==5.2.7
 django-appconf==1.0.5
-django-avatar>=4.0
+django-avatar>=7.0
 django-compressor>=2.0,<=2.4
 django-countries>=3.3
 django-followit==0.5.0


### PR DESCRIPTION
Error was introduced when django-avatar added support for rectangular avatars

Previously, method `get_primary_avatar` accepted only the `size` argument

Now, it has two args: `width` and `height`.

I took the simpler approach of assuming the avatars are always a square.

Ref: https://github.com/jazzband/django-avatar/commit/99a979b057e0a099eb1149eaac0956ce7a4b4fde

Closes #927