### PR TITLE
Fix attribute name for active class in init_page.js

### DIFF
--- a/askbot/media/js/pages/question/init_page.js
+++ b/askbot/media/js/pages/question/init_page.js
@@ -21,7 +21,7 @@ function initEditor(){
 PostVote.init();
 
 $(document).ready(function(){
-  $("#js-answers-sort-" + askbot['data']['answersSortTab']).attr('className',"js-active");
+  $("#js-answers-sort-" + askbot['data']['answersSortTab']).attr('class',"js-active");
 
   if (askbot['data']['threadIsClosed'] === false) {
     initEditor();


### PR DESCRIPTION
When adding styles to a sort nav, the active nav element can be selected using `.components--sort-nav a[className="js-selected"]`. However, it seems the intention is to make a class attribute so that the active element can be selected with `.components--sort-nav a.js-selected`.

Other notes
- I did not investigate any downstream impacts.
- Assigning a `className` attribute also occurs in `jinja2/user_profile/user_edit.html`. This might also be worth reviewing.