### PR TITLE
refactor: update code according to deprecations and removals in Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.11.7]
+        python-version: [3.11.7, 3.12.3]
 
 #    services:
 #      postgres:
@@ -32,7 +32,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     # see https://github.com/pre-commit/action/#using-this-action
     - name: pre-commit checks
-      uses: pre-commit/action@v2.0.0
+      uses: pre-commit/action@v3.0.1
       env:
         # it's okay for github to commit to main/master
         SKIP: no-commit-to-branch

--- a/askbot/__init__.py
+++ b/askbot/__init__.py
@@ -23,7 +23,7 @@ REQUIREMENTS = {
     'bleach': 'bleach==5.0.1',
     'bs4': 'beautifulsoup4<=4.7.1',
     'compressor': 'django-compressor>=3.0,<=4.4',
-    'celery': 'celery==5.2.7',
+    'celery': 'celery==5.3.0',
     'django': 'django>=3.0,<5.0',
     'django_countries': 'django-countries>=3.3',
     'django_jinja': 'django-jinja>=2.0',

--- a/askbot/deployment/path_utils.py
+++ b/askbot/deployment/path_utils.py
@@ -3,7 +3,7 @@ import os
 import os.path
 import re
 import glob
-import imp
+import importlib
 
 
 IMPORT_RE1 = re.compile(r'from django.*import')
@@ -28,7 +28,7 @@ def is_dir_python_module(directory):
     """True if directory is not taken by another python module"""
     dir_name = os.path.basename(directory)
     try:
-        imp.find_module(dir_name)
+        importlib.find_module(dir_name)
         return True
     except ImportError:
         return False

--- a/askbot/startup_procedures.py
+++ b/askbot/startup_procedures.py
@@ -12,7 +12,7 @@ from askbot.conf.static_settings import settings as django_settings
 import askbot
 import django
 import os
-import pkg_resources
+import importlib
 import re
 import sys
 import urllib.request, urllib.parse, urllib.error
@@ -262,7 +262,7 @@ def test_specs(req):
 
     if not req.specs:
         return
-    mod_ver = pkg_resources.get_distribution(req.name).version
+    mod_ver = importlib.metadata.version(req.name)
     mod_ver = map_int(mod_ver.split('.'))
     try:
         for spec in req.specs:
@@ -904,11 +904,13 @@ def test_versions():
     if dj_ver < (3, 0) or dj_ver >= (5, 0):
         errors.append('This version of Askbot supports django 3.x - 4.x ' + upgrade_msg)
     elif py_ver[:3] < (3, 6, 0):
-        errors.append('Askbot requires Python 3.6 - 3.10')
-    elif py_ver[:3] >= (3, 12, 0):
-        errors.append("""Askbot was not tested with Python > 3.11.x
-Try adding ASKBOT_SELF_TEST = False to the settings.py
-to test if your version of Python works and please let us know.""")
+        errors.append('Askbot requires Python 3.6 - 3.12')
+    elif py_ver[:3] >= (3, 13, 0):
+        errors.append(
+            'Askbot was not tested with Python > 3.12.x\n'
+            'Try adding ASKBOT_SELF_TEST = False to the settings.py\n'
+            'to test if your version of Python works and please let us know.'
+        )
 
     print_errors(errors)
 

--- a/askbot/tests/test_management_commands.py
+++ b/askbot/tests/test_management_commands.py
@@ -223,7 +223,7 @@ class ManagementCommandTests(AskbotTestCase):
         subs = models.EmailFeedSetting.objects.filter(
                                                 subscriber = user,
                                             )
-        self.assertEquals(subs.count(), 6)
+        self.assertEqual(subs.count(), 6)
         #try to log in
         user = auth.authenticate(username=username, password=password)
         self.assertTrue(user is not None)

--- a/askbot/utils/url_utils.py
+++ b/askbot/utils/url_utils.py
@@ -1,5 +1,5 @@
 """utilities to work with the urls"""
-import imp
+import importlib
 import sys
 import urllib.parse
 from django.urls import reverse, re_path
@@ -12,7 +12,7 @@ def reload_urlconf():
     clear_url_caches()
     urlconf = django_settings.ROOT_URLCONF
     if urlconf in sys.modules:
-        imp.reload(sys.modules[urlconf])
+        importlib.reload(sys.modules[urlconf])
 
 def reverse_i18n(lang, *args, **kwargs):
     """reverses url in requested language"""

--- a/askbot_requirements.txt
+++ b/askbot_requirements.txt
@@ -4,7 +4,7 @@ Jinja2>=2.10,<3.1
 akismet==1.0.1
 beautifulsoup4<=4.7.1
 bleach==5.0.1
-celery==5.2.7
+celery==5.3.0
 django-appconf==1.0.5
 django-avatar>=7.0
 django-compressor>=3.0,<=4.4


### PR DESCRIPTION
This commit makes the following changes to address deprecations and removals in Python 3.12:

- Replace usage of `pkg_resources` with `importlib` as `pkg_resources` is deprecated and will be removed in December 2025. see: https://setuptools.pypa.io/en/stable/history.html#v80-9-0
- Upgrade `celery` to version `5.3.0` which includes fixes for the `entry_points` interface change in 3.12. This change was necessary to address unit test failures in 3.12. see: https://github.com/celery/celery/pull/7785
- Replace `assertEquals` with `assertEqual` in unit tests as `assertEquals` has been removed in 3.12. see: https://docs.python.org/3.12/whatsnew/3.12.html#unittest-testcase-removed-aliases

This commit also includes the following changes as a consequence of the above updates:
- Update `startup_procedures.py` to enable use of 3.12.
- In the `tests.yml` workflow, add 3.12 to the versions matrix.

In addition, this commit also makes the following change:
- Update `pre-commit/action` to the latest version `v3.0.1` to address the following runtime error with `v.2.0.0`: github.com/actions/cache/issues/820