### PR TITLE
Fix session datetime serialization for Django JSONSerializer

### DIFF
--- a/askbot/models/__init__.py
+++ b/askbot/models/__init__.py
@@ -4164,11 +4164,18 @@ def record_question_visit(request, question, timestamp, **kwargs):
         if 'question_view_times' not in request.session:
             request.session['question_view_times'] = {}
 
-        last_seen = request.session['question_view_times'].get(question.id, None)
+        last_seen_raw = request.session['question_view_times'].get(question.id, None)
 
-        if last_seen and timezone.is_naive(last_seen) \
-            and getattr(django_settings, 'USE_TZ', False):
-            last_seen = timezone.make_aware(last_seen, datetime.timezone.utc)
+        # Parse ISO string back to datetime (session stores strings for JSON serialization)
+        last_seen = None
+        if last_seen_raw:
+            if isinstance(last_seen_raw, str):
+                last_seen = datetime.datetime.fromisoformat(last_seen_raw)
+            else:
+                last_seen = last_seen_raw
+            if timezone.is_naive(last_seen) \
+                and getattr(django_settings, 'USE_TZ', False):
+                last_seen = timezone.make_aware(last_seen, datetime.timezone.utc)
 
         update_view_count = False
         if question.thread.last_activity_by_id != request.user.id:
@@ -4178,7 +4185,7 @@ def record_question_visit(request, question, timestamp, **kwargs):
             else:
                 update_view_count = True
 
-        request.session['question_view_times'][question.id] = timestamp
+        request.session['question_view_times'][question.id] = timestamp.isoformat()
         #2) run the slower jobs in a celery task
         from askbot import tasks
         defer_celery_task(

--- a/askbot/tests/test_session_datetime.py
+++ b/askbot/tests/test_session_datetime.py
@@ -1,0 +1,79 @@
+"""Tests for session datetime serialization in record_question_visit."""
+import datetime
+from unittest.mock import patch
+
+from django.test import RequestFactory
+from django.utils import timezone
+from django.contrib.sessions.backends.db import SessionStore
+
+from askbot.tests.utils import AskbotTestCase
+
+
+class SessionDatetimeTests(AskbotTestCase):
+    """Tests that record_question_visit stores ISO strings in session."""
+
+    def setUp(self):
+        self.user = self.create_user('visitor')
+        self.question = self.post_question(user=self.user)
+        self.factory = RequestFactory()
+
+    def _make_request(self, user=None):
+        request = self.factory.get(self.question.get_absolute_url())
+        request.user = user or self.user
+        request.session = SessionStore()
+        return request
+
+    @patch('askbot.models.defer_celery_task')
+    @patch('askbot.models.functions.not_a_robot_request', return_value=True)
+    def test_stores_iso_string(self, mock_robot, mock_defer):
+        """record_question_visit should store ISO string, not datetime."""
+        from askbot.models import record_question_visit
+        request = self._make_request()
+
+        record_question_visit(request, self.question, timezone.now())
+
+        value = request.session['question_view_times'][self.question.id]
+        self.assertIsInstance(value, str)
+        # Should be parseable as ISO
+        parsed = datetime.datetime.fromisoformat(value)
+        self.assertIsNotNone(parsed)
+
+    @patch('askbot.models.defer_celery_task')
+    @patch('askbot.models.functions.not_a_robot_request', return_value=True)
+    def test_reads_iso_string(self, mock_robot, mock_defer):
+        """record_question_visit should handle pre-existing ISO strings."""
+        from askbot.models import record_question_visit
+        request = self._make_request()
+
+        # Pre-populate session with an ISO string from a past visit
+        past = (timezone.now() - datetime.timedelta(hours=1)).isoformat()
+        request.session['question_view_times'] = {
+            self.question.id: past
+        }
+
+        # Should not raise
+        record_question_visit(request, self.question, timezone.now())
+
+        # Value should be updated — verify it's still a string
+        value = request.session['question_view_times'][self.question.id]
+        self.assertIsInstance(value, str)
+        # Parse both to compare timestamps (new should be >= past)
+        parsed_new = datetime.datetime.fromisoformat(value)
+        parsed_past = datetime.datetime.fromisoformat(past)
+        self.assertGreaterEqual(parsed_new, parsed_past)
+
+    @patch('askbot.models.defer_celery_task')
+    @patch('askbot.models.functions.not_a_robot_request', return_value=True)
+    def test_first_visit_updates_view_count(self, mock_robot, mock_defer):
+        """First visit to a question should pass update_view_count=True."""
+        from askbot.models import record_question_visit
+
+        # Use a different user so last_activity_by check passes
+        other_user = self.create_user('other_visitor')
+        request = self._make_request(user=other_user)
+
+        record_question_visit(request, self.question, timezone.now())
+
+        mock_defer.assert_called_once()
+        call_kwargs = mock_defer.call_args[1]['kwargs']
+        self.assertTrue(call_kwargs['update_view_count'])


### PR DESCRIPTION
Problem:  record_question_visit() stores timezone.now() directly in the session, which fails with Django's JSONSerializer (default since 4.1) because datetime objects are not JSON-serializable. This causes TypeError on every question page view for logged-in users.

Fix:  Store timestamps as ISO 8601 strings and parse them back on read. Handles both new string values and legacy datetime objects for backward compatibility with existing sessions.