### PR TITLE
Add optional email alerts for new questions, answers, and comments

### DIFF
--- a/askbot/apps.py
+++ b/askbot/apps.py
@@ -37,3 +37,7 @@ class AskbotConfig(AppConfig):
         import followit
         user_model = get_user_model()
         followit.register(user_model)
+
+        if getattr(django_settings, 'POST_ALERT_EMAIL', None):
+            from askbot.post_alerts import connect as connect_post_alerts
+            connect_post_alerts()

--- a/askbot/post_alerts.py
+++ b/askbot/post_alerts.py
@@ -1,0 +1,89 @@
+"""Email alerts for new posts.
+
+Sends an email to POST_ALERT_EMAIL (Django setting) whenever a
+question, answer, or comment is posted. Useful for low-traffic sites
+or during initial rollout monitoring.
+
+Disable by removing POST_ALERT_EMAIL from settings.py.
+"""
+import logging
+from django.conf import settings as django_settings
+from askbot import signals
+from askbot.conf import settings as askbot_settings
+
+logger = logging.getLogger(__name__)
+
+
+def _get_site_url():
+    """Get the site base URL from Django's sites framework."""
+    try:
+        from django.contrib.sites.models import Site
+        site = Site.objects.get_current()
+        return f"https://{site.domain}"
+    except Exception:
+        return ''
+
+
+def _send_post_alert(post_type, post, user):
+    """Send a notification email about a new post."""
+    alert_email = getattr(django_settings, 'POST_ALERT_EMAIL', None)
+    if not alert_email:
+        return
+
+    try:
+        from askbot.mail import send_mail
+
+        site_url = _get_site_url()
+        url = post.get_absolute_url() if hasattr(post, 'get_absolute_url') else ''
+        full_url = f"{site_url}{url}" if url else ''
+        preview = post.text[:500] if hasattr(post, 'text') else ''
+
+        url_link = f'<a href="{full_url}">{full_url}</a>' if full_url else ''
+        preview_html = f'<p>{preview}</p>' if preview else ''
+
+        if post_type == 'question':
+            title = post.thread.title if hasattr(post, 'thread') else str(post)
+            body = (f"<p>New question by <b>{user.username}</b> ({user.email})</p>"
+                    f"<p>Title: {title}<br>URL: {url_link}</p>"
+                    f"{preview_html}")
+        elif post_type == 'answer':
+            question = post.thread.title if hasattr(post, 'thread') else ''
+            body = (f"<p>New answer by <b>{user.username}</b> ({user.email})</p>"
+                    f"<p>Question: {question}<br>URL: {url_link}</p>"
+                    f"{preview_html}")
+        elif post_type == 'comment':
+            body = (f"<p>New comment by <b>{user.username}</b> ({user.email})</p>"
+                    f"<p>URL: {url_link}</p>"
+                    f"{preview_html}")
+        else:
+            body = f"<p>New {post_type} by {user.username}</p>"
+
+        subject = f"New {post_type} by {user.username}"
+
+        send_mail(
+            subject_line=subject,
+            body_text=body,
+            recipient_list=[alert_email],
+        )
+
+    except Exception as e:
+        logger.error(f"Failed to send post alert: {e}")
+
+
+def on_new_question(sender, question, user, **kwargs):
+    _send_post_alert('question', question, user)
+
+
+def on_new_answer(sender, answer, user, **kwargs):
+    _send_post_alert('answer', answer, user)
+
+
+def on_new_comment(sender, comment, user, **kwargs):
+    _send_post_alert('comment', comment, user)
+
+
+def connect():
+    """Connect signal handlers. Call from AppConfig.ready()."""
+    signals.new_question_posted.connect(on_new_question)
+    signals.new_answer_posted.connect(on_new_answer)
+    signals.new_comment_posted.connect(on_new_comment)

--- a/askbot/tests/test_post_alerts.py
+++ b/askbot/tests/test_post_alerts.py
@@ -1,0 +1,102 @@
+"""Tests for post alert emails."""
+from unittest.mock import patch, MagicMock
+
+from django.test import TestCase, override_settings
+
+from askbot import signals
+from askbot.post_alerts import (
+    _send_post_alert, on_new_question, on_new_answer, on_new_comment, connect
+)
+
+
+def _make_post(post_type='question', text='Test content', title='Test title'):
+    """Create a mock post object."""
+    post = MagicMock()
+    post.post_type = post_type
+    post.text = text
+    post.thread.title = title
+    post.get_absolute_url.return_value = '/question/1/test/'
+    return post
+
+
+def _make_user(username='testuser', email='test@example.com'):
+    user = MagicMock()
+    user.username = username
+    user.email = email
+    return user
+
+
+class PostAlertTests(TestCase):
+    """Tests for _send_post_alert()."""
+
+    def test_no_setting_noop(self):
+        """No POST_ALERT_EMAIL setting means send_mail is not called."""
+        with override_settings():
+            # Remove the setting entirely
+            with self.settings(POST_ALERT_EMAIL=None):
+                with patch('askbot.mail.send_mail') as mock_send:
+                    _send_post_alert('question', _make_post(), _make_user())
+                    mock_send.assert_not_called()
+
+    @override_settings(POST_ALERT_EMAIL='admin@example.com')
+    def test_question_alert(self):
+        """Question alert should include title in body."""
+        post = _make_post(post_type='question', title='How to test?')
+        user = _make_user()
+        with patch('askbot.mail.send_mail') as mock_send:
+            _send_post_alert('question', post, user)
+            mock_send.assert_called_once()
+            kwargs = mock_send.call_args[1]
+            self.assertIn('question', kwargs['subject_line'])
+            self.assertIn('How to test?', kwargs['body_text'])
+            self.assertEqual(kwargs['recipient_list'], ['admin@example.com'])
+
+    @override_settings(POST_ALERT_EMAIL='admin@example.com')
+    def test_answer_alert(self):
+        """Answer alert should be sent with answer info."""
+        post = _make_post(post_type='answer')
+        user = _make_user()
+        with patch('askbot.mail.send_mail') as mock_send:
+            _send_post_alert('answer', post, user)
+            mock_send.assert_called_once()
+            self.assertIn('answer', mock_send.call_args[1]['subject_line'])
+
+    @override_settings(POST_ALERT_EMAIL='admin@example.com')
+    def test_comment_alert(self):
+        """Comment alert should be sent."""
+        post = _make_post(post_type='comment')
+        user = _make_user()
+        with patch('askbot.mail.send_mail') as mock_send:
+            _send_post_alert('comment', post, user)
+            mock_send.assert_called_once()
+            self.assertIn('comment', mock_send.call_args[1]['subject_line'])
+
+    @override_settings(POST_ALERT_EMAIL='admin@example.com')
+    def test_exception_caught(self):
+        """Exceptions from send_mail should not propagate."""
+        post = _make_post()
+        user = _make_user()
+        with patch('askbot.mail.send_mail',
+                   side_effect=Exception('SMTP error')):
+            # Should not raise
+            _send_post_alert('question', post, user)
+
+    def test_connect_wires_signals(self):
+        """connect() should register receivers on the correct signals."""
+        # Disconnect first to avoid duplicate connections
+        signals.new_question_posted.disconnect(on_new_question)
+        signals.new_answer_posted.disconnect(on_new_answer)
+        signals.new_comment_posted.disconnect(on_new_comment)
+
+        connect()
+
+        receivers_q = [r[1]() for r in signals.new_question_posted.receivers
+                       if r[1]() is not None]
+        receivers_a = [r[1]() for r in signals.new_answer_posted.receivers
+                       if r[1]() is not None]
+        receivers_c = [r[1]() for r in signals.new_comment_posted.receivers
+                       if r[1]() is not None]
+
+        self.assertIn(on_new_question, receivers_q)
+        self.assertIn(on_new_answer, receivers_a)
+        self.assertIn(on_new_comment, receivers_c)


### PR DESCRIPTION
Sends an email to a configurable address when new content is posted. Useful for low-traffic sites or monitoring during initial rollout. Hooks into existing askbot signals (new_question_posted, etc.) via AppConfig.ready().

Opt-in: does nothing unless POST_ALERT_EMAIL is set in Django settings.