### PR TITLE
Add request logging middleware for DDoS monitoring and analysis

### DIFF
--- a/askbot/conf/__init__.py
+++ b/askbot/conf/__init__.py
@@ -33,6 +33,7 @@ def init():
     import askbot.conf.access_control
     import askbot.conf.site_modes
     import askbot.conf.words
+    import askbot.conf.request_logging
 
 #import main settings object
 from askbot.conf.settings_wrapper import settings

--- a/askbot/conf/request_logging.py
+++ b/askbot/conf/request_logging.py
@@ -1,0 +1,33 @@
+"""Request logging livesettings configuration."""
+from askbot.conf.settings_wrapper import settings
+from askbot.conf.super_groups import EXTERNAL_SERVICES
+from livesettings import values as livesettings
+from django.utils.translation import gettext_lazy as _
+
+REQUEST_LOGGING = livesettings.ConfigurationGroup(
+    'REQUEST_LOGGING',
+    _('Request logging'),
+    super_group=EXTERNAL_SERVICES
+)
+
+settings.register(
+    livesettings.BooleanValue(
+        REQUEST_LOGGING,
+        'REQUEST_LOG_ENABLED',
+        description=_('Enable request logging'),
+        default=True,
+        help_text=_('Log every request with IP, method, path, status, '
+                    'response time, and user. Uses the askbot.request_log '
+                    'Python logger.')
+    )
+)
+
+settings.register(
+    livesettings.BooleanValue(
+        REQUEST_LOGGING,
+        'REQUEST_LOG_IGNORE_STATIC',
+        description=_('Ignore static file requests'),
+        default=True,
+        help_text=_('Skip logging requests for /m/ and /upfiles/ paths.')
+    )
+)

--- a/askbot/middleware/request_log.py
+++ b/askbot/middleware/request_log.py
@@ -1,0 +1,54 @@
+"""Request logging middleware for DDoS monitoring and analysis."""
+import logging
+import time
+
+from askbot.conf import settings as askbot_settings
+
+
+logger = logging.getLogger('askbot.request_log')
+
+STATIC_PREFIXES = ('/m/', '/upfiles/')
+
+
+class RequestLogMiddleware:
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if not askbot_settings.REQUEST_LOG_ENABLED:
+            return self.get_response(request)
+
+        path = request.path
+
+        # Optionally skip static file paths
+        if askbot_settings.REQUEST_LOG_IGNORE_STATIC:
+            if any(path.startswith(p) for p in STATIC_PREFIXES):
+                return self.get_response(request)
+
+        start = time.monotonic()
+        response = self.get_response(request)
+        duration = time.monotonic() - start
+
+        # Use X-Forwarded-For when behind a reverse proxy (e.g., nginx)
+        forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR', '')
+        ip = forwarded_for.split(',')[0].strip() if forwarded_for else request.META.get('REMOTE_ADDR', '')
+        method = request.method
+        status = response.status_code
+        user = request.user.username if hasattr(request, 'user') and request.user.is_authenticated else 'anonymous'
+        ratelimited = getattr(request, '_ratelimited', False)
+
+        parts = [
+            'ip=%s' % ip,
+            'method=%s' % method,
+            'path=%s' % path,
+            'status=%s' % status,
+            'time=%.3fs' % duration,
+            'user=%s' % user,
+        ]
+        if ratelimited:
+            parts.append('ratelimited=true')
+
+        logger.info(' '.join(parts))
+
+        return response

--- a/askbot/setup_templates/settings.py.jinja2
+++ b/askbot/setup_templates/settings.py.jinja2
@@ -142,6 +142,7 @@ MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
 
+    'askbot.middleware.request_log.RequestLogMiddleware',
     'askbot.middleware.analytics_session.AnalyticsSessionMiddleware',
     'askbot.middleware.head_request.HeadRequestMiddleware',
     'askbot.middleware.anon_user.ConnectToSessionMessagesMiddleware',
@@ -280,6 +281,33 @@ logging.basicConfig(
     level=logging.CRITICAL,
     format='%(pathname)s TIME: %(asctime)s MSG: %(filename)s:%(funcName)s:%(lineno)d %(message)s',
 )
+
+# To log requests to a file (for DDoS analysis / fail2ban), enable
+# REQUEST_LOG_ENABLED in livesettings and configure LOGGING:
+#LOGGING = {
+#    'version': 1,
+#    'disable_existing_loggers': False,
+#    'formatters': {
+#        'request_log': {
+#            'format': '[%(asctime)s] %(message)s',
+#        },
+#    },
+#    'handlers': {
+#        'request_log_file': {
+#            'level': 'INFO',
+#            'class': 'logging.FileHandler',
+#            'filename': os.path.join(PROJECT_ROOT, 'log', 'requests.log'),
+#            'formatter': 'request_log',
+#        },
+#    },
+#    'loggers': {
+#        'askbot.request_log': {
+#            'handlers': ['request_log_file'],
+#            'level': 'INFO',
+#            'propagate': False,
+#        },
+#    },
+#}
 
 ###########################
 #

--- a/askbot/tests/test_request_logging.py
+++ b/askbot/tests/test_request_logging.py
@@ -1,0 +1,107 @@
+"""Tests for request logging middleware."""
+from unittest.mock import patch
+
+from django.test import TestCase, RequestFactory
+
+from askbot.tests.utils import with_settings
+from askbot.middleware.request_log import RequestLogMiddleware
+
+
+class RequestLogMiddlewareTests(TestCase):
+    """Tests for the request logging middleware."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def _make_middleware(self, status_code=200):
+        response = type('Response', (), {'status_code': status_code})()
+        return RequestLogMiddleware(lambda request: response)
+
+    @with_settings(REQUEST_LOG_ENABLED=True, REQUEST_LOG_IGNORE_STATIC=True)
+    def test_logs_request(self):
+        middleware = self._make_middleware()
+        request = self.factory.get('/questions/')
+        request.META['REMOTE_ADDR'] = '1.2.3.4'
+        request.user = type('User', (), {
+            'is_authenticated': False,
+            'username': 'anonymous'
+        })()
+
+        with patch('askbot.middleware.request_log.logger') as mock_logger:
+            middleware(request)
+            mock_logger.info.assert_called_once()
+            log_msg = mock_logger.info.call_args[0][0]
+            self.assertIn('ip=1.2.3.4', log_msg)
+            self.assertIn('method=GET', log_msg)
+            self.assertIn('path=/questions/', log_msg)
+            self.assertIn('status=200', log_msg)
+            self.assertIn('user=anonymous', log_msg)
+            self.assertNotIn('ratelimited', log_msg)
+
+    @with_settings(REQUEST_LOG_ENABLED=True, REQUEST_LOG_IGNORE_STATIC=True)
+    def test_logs_ratelimited_flag(self):
+        middleware = self._make_middleware(status_code=429)
+        request = self.factory.get('/questions/')
+        request.META['REMOTE_ADDR'] = '1.2.3.4'
+        request._ratelimited = True
+        request.user = type('User', (), {
+            'is_authenticated': False,
+            'username': 'anonymous'
+        })()
+
+        with patch('askbot.middleware.request_log.logger') as mock_logger:
+            middleware(request)
+            log_msg = mock_logger.info.call_args[0][0]
+            self.assertIn('ratelimited=true', log_msg)
+
+    @with_settings(REQUEST_LOG_ENABLED=True, REQUEST_LOG_IGNORE_STATIC=True)
+    def test_skips_static_paths(self):
+        middleware = self._make_middleware()
+        request = self.factory.get('/m/default/media/js/utils.js')
+        request.META['REMOTE_ADDR'] = '1.2.3.4'
+
+        with patch('askbot.middleware.request_log.logger') as mock_logger:
+            middleware(request)
+            mock_logger.info.assert_not_called()
+
+    @with_settings(REQUEST_LOG_ENABLED=True, REQUEST_LOG_IGNORE_STATIC=False)
+    def test_logs_static_when_not_ignored(self):
+        middleware = self._make_middleware()
+        request = self.factory.get('/m/default/media/js/utils.js')
+        request.META['REMOTE_ADDR'] = '1.2.3.4'
+        request.user = type('User', (), {
+            'is_authenticated': False,
+            'username': 'anonymous'
+        })()
+
+        with patch('askbot.middleware.request_log.logger') as mock_logger:
+            middleware(request)
+            mock_logger.info.assert_called_once()
+
+    @with_settings(REQUEST_LOG_ENABLED=True, REQUEST_LOG_IGNORE_STATIC=True)
+    def test_x_forwarded_for_logged(self):
+        """Request log should use X-Forwarded-For IP when present."""
+        middleware = self._make_middleware()
+        request = self.factory.get('/questions/')
+        request.META['REMOTE_ADDR'] = '127.0.0.1'
+        request.META['HTTP_X_FORWARDED_FOR'] = '203.0.113.50'
+        request.user = type('User', (), {
+            'is_authenticated': False,
+            'username': 'anonymous'
+        })()
+
+        with patch('askbot.middleware.request_log.logger') as mock_logger:
+            middleware(request)
+            log_msg = mock_logger.info.call_args[0][0]
+            self.assertIn('ip=203.0.113.50', log_msg)
+            self.assertNotIn('ip=127.0.0.1', log_msg)
+
+    @with_settings(REQUEST_LOG_ENABLED=False)
+    def test_disabled_skips_logging(self):
+        middleware = self._make_middleware()
+        request = self.factory.get('/questions/')
+        request.META['REMOTE_ADDR'] = '1.2.3.4'
+
+        with patch('askbot.middleware.request_log.logger') as mock_logger:
+            middleware(request)
+            mock_logger.info.assert_not_called()


### PR DESCRIPTION
Logs each request with IP, method, path, status code, response time, user, and rate-limited flag to the askbot.request_log Python logger. Uses X-Forwarded-For header when behind a reverse proxy.

Configurable via livesettings: enable/disable logging, ignore static file paths (/m/, /upfiles/). Includes commented-out LOGGING config example in settings template for file-based log output.

The ratelimited=true flag integrates with rate limiting middleware (if present) but degrades gracefully without it.