### PR TITLE
Add per-IP rate limiting middleware with registration and content velocity limiting

### DIFF
--- a/askbot/conf/__init__.py
+++ b/askbot/conf/__init__.py
@@ -33,6 +33,7 @@ def init():
     import askbot.conf.access_control
     import askbot.conf.site_modes
     import askbot.conf.words
+    import askbot.conf.rate_limiting
 
 #import main settings object
 from askbot.conf.settings_wrapper import settings

--- a/askbot/conf/rate_limiting.py
+++ b/askbot/conf/rate_limiting.py
@@ -1,0 +1,155 @@
+"""Rate limiting livesettings configuration."""
+from askbot.conf.settings_wrapper import settings
+from askbot.conf.super_groups import EXTERNAL_SERVICES
+from livesettings import values as livesettings
+from django.utils.translation import gettext_lazy as _
+
+RATE_LIMITING = livesettings.ConfigurationGroup(
+    'RATE_LIMITING',
+    _('Rate limiting'),
+    super_group=EXTERNAL_SERVICES
+)
+
+settings.register(
+    livesettings.BooleanValue(
+        RATE_LIMITING,
+        'RATE_LIMIT_ENABLED',
+        description=_('Enable rate limiting'),
+        default=True,
+        help_text=_('Master switch for per-IP request rate limiting.')
+    )
+)
+
+settings.register(
+    livesettings.IntegerValue(
+        RATE_LIMITING,
+        'RATE_LIMIT_REQUESTS_PER_WINDOW',
+        description=_('Max requests per IP per window'),
+        default=60,
+        help_text=_('Number of requests allowed per IP within the sliding window.')
+    )
+)
+
+settings.register(
+    livesettings.IntegerValue(
+        RATE_LIMITING,
+        'RATE_LIMIT_WINDOW_SECONDS',
+        description=_('Rate limit window (seconds)'),
+        default=60,
+        help_text=_('Duration of the sliding window in seconds.')
+    )
+)
+
+settings.register(
+    livesettings.IntegerValue(
+        RATE_LIMITING,
+        'RATE_LIMIT_CACHE_SIZE',
+        description=_('Max tracked IPs'),
+        default=200000,
+        help_text=_('Maximum number of IPs to track in memory. '
+                    'Each tracked IP uses approximately 3KB of memory '
+                    '(50,000 IPs ≈ 150MB, 200,000 ≈ 600MB). '
+                    'Set based on available server RAM. IPs exceeding this '
+                    'limit evict the oldest entries, so use the ban command '
+                    'for persistent blocking.')
+    )
+)
+
+settings.register(
+    livesettings.BooleanValue(
+        RATE_LIMITING,
+        'RATE_LIMIT_BAN_ENABLED',
+        description=_('Enable ban command on rate limit'),
+        default=False,
+        help_text=_('When enabled, executes the ban command below '
+                    'when an IP exceeds the rate limit. Note: the web '
+                    'process typically lacks permissions to run '
+                    'fail2ban-client directly. The recommended approach '
+                    'for fail2ban is to enable request logging instead '
+                    'and configure fail2ban to watch the log file for '
+                    '"ratelimited=true" entries. Use this setting only '
+                    'for commands the web process can run (e.g. writing '
+                    'to a file or calling a local API).')
+    )
+)
+
+settings.register(
+    livesettings.StringValue(
+        RATE_LIMITING,
+        'RATE_LIMIT_BAN_COMMAND',
+        description=_('Ban command template'),
+        default='',
+        help_text=_('Command to execute when banning an IP. '
+                    'Use {ip} as placeholder. Must be runnable by the '
+                    'web process user without elevated privileges.')
+    )
+)
+
+# --- Registration rate limiting ---
+
+settings.register(
+    livesettings.BooleanValue(
+        RATE_LIMITING,
+        'REGISTRATION_RATE_LIMIT_ENABLED',
+        description=_('Enable registration rate limiting'),
+        default=True,
+        help_text=_('Per-IP throttle on signup endpoints to slow '
+                    'automated account creation.')
+    )
+)
+
+settings.register(
+    livesettings.IntegerValue(
+        RATE_LIMITING,
+        'REGISTRATION_RATE_LIMIT_PER_IP',
+        description=_('Max registrations per IP per window'),
+        default=3,
+        help_text=_('Number of registrations allowed per IP within '
+                    'the sliding window.')
+    )
+)
+
+settings.register(
+    livesettings.IntegerValue(
+        RATE_LIMITING,
+        'REGISTRATION_RATE_LIMIT_WINDOW_SECONDS',
+        description=_('Registration rate limit window (seconds)'),
+        default=86400,
+        help_text=_('Duration of the sliding window in seconds. '
+                    'Default: 86400 (1 day).')
+    )
+)
+
+# --- Content velocity limiting ---
+
+settings.register(
+    livesettings.BooleanValue(
+        RATE_LIMITING,
+        'CONTENT_VELOCITY_ENABLED',
+        description=_('Enable content velocity limiting'),
+        default=False,
+        help_text=_('Per-user post limit for watched users to slow '
+                    'sophisticated spammers.')
+    )
+)
+
+settings.register(
+    livesettings.IntegerValue(
+        RATE_LIMITING,
+        'CONTENT_VELOCITY_MAX_POSTS',
+        description=_('Max posts per window (watched users)'),
+        default=5,
+        help_text=_('Maximum posts a watched user can make within '
+                    'the velocity window.')
+    )
+)
+
+settings.register(
+    livesettings.IntegerValue(
+        RATE_LIMITING,
+        'CONTENT_VELOCITY_WINDOW_MINUTES',
+        description=_('Content velocity window (minutes)'),
+        default=60,
+        help_text=_('Duration of the content velocity window in minutes.')
+    )
+)

--- a/askbot/middleware/ratelimit.py
+++ b/askbot/middleware/ratelimit.py
@@ -1,0 +1,140 @@
+"""Per-IP request rate limiting middleware using an in-memory sliding window."""
+import collections
+import threading
+import time
+
+from django.conf import settings as django_settings
+from django.http import HttpResponse
+
+from askbot.conf import settings as askbot_settings
+
+
+# Module-level state: IP -> deque of timestamps
+_request_log = {}
+_registration_log = {}
+_lock = threading.Lock()
+
+
+def _cleanup_stale(now, window):
+    """Remove IPs that haven't been seen within the window."""
+    stale = [ip for ip, times in _request_log.items()
+             if not times or (now - times[-1]) > window]
+    for ip in stale:
+        del _request_log[ip]
+
+
+def _cleanup_stale_registrations(now, window):
+    """Remove IPs that haven't registered within the window."""
+    stale = [ip for ip, times in _registration_log.items()
+             if not times or (now - times[-1]) > window]
+    for ip in stale:
+        del _registration_log[ip]
+
+
+# Registration paths to match (suffix matching for i18n variants)
+_REGISTRATION_SUFFIXES = ('/account/signup/', '/account/register/')
+
+
+class RateLimitMiddleware:
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self._cleanup_counter = 0
+
+    def __call__(self, request):
+        if not askbot_settings.RATE_LIMIT_ENABLED:
+            return self.get_response(request)
+
+        # Use X-Forwarded-For when behind a reverse proxy (e.g., nginx)
+        forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR', '')
+        ip = forwarded_for.split(',')[0].strip() if forwarded_for else request.META.get('REMOTE_ADDR', '')
+
+        # Whitelisted IPs bypass rate limiting
+        internal_ips = getattr(django_settings, 'ASKBOT_INTERNAL_IPS', None)
+        if internal_ips and ip in internal_ips:
+            return self.get_response(request)
+
+        now = time.monotonic()
+        window = askbot_settings.RATE_LIMIT_WINDOW_SECONDS
+        max_requests = askbot_settings.RATE_LIMIT_REQUESTS_PER_WINDOW
+        max_tracked = askbot_settings.RATE_LIMIT_CACHE_SIZE
+
+        with _lock:
+            # Periodic cleanup every 1000 requests
+            self._cleanup_counter += 1
+            if self._cleanup_counter >= 1000:
+                self._cleanup_counter = 0
+                _cleanup_stale(now, window)
+                reg_window = askbot_settings.REGISTRATION_RATE_LIMIT_WINDOW_SECONDS
+                _cleanup_stale_registrations(now, reg_window)
+                # Evict oldest entries if over capacity
+                while len(_request_log) > max_tracked:
+                    oldest_ip = min(_request_log,
+                                    key=lambda k: _request_log[k][-1]
+                                    if _request_log[k] else 0)
+                    del _request_log[oldest_ip]
+
+            timestamps = _request_log.get(ip)
+            if timestamps is None:
+                timestamps = collections.deque()
+                _request_log[ip] = timestamps
+
+            # Trim timestamps outside the window
+            cutoff = now - window
+            while timestamps and timestamps[0] < cutoff:
+                timestamps.popleft()
+
+            if len(timestamps) >= max_requests:
+                # Mark on the request so logging middleware can see it
+                request._ratelimited = True
+
+                # Optional ban command
+                if askbot_settings.RATE_LIMIT_BAN_ENABLED:
+                    ban_cmd = askbot_settings.RATE_LIMIT_BAN_COMMAND
+                    if ban_cmd and '{ip}' in ban_cmd:
+                        import subprocess
+                        try:
+                            subprocess.Popen(
+                                ban_cmd.format(ip=ip).split(),
+                                stdout=subprocess.DEVNULL,
+                                stderr=subprocess.DEVNULL
+                            )
+                        except OSError:
+                            pass
+
+                return HttpResponse(
+                    'Rate limit exceeded. Please slow down.',
+                    status=429,
+                    content_type='text/plain'
+                )
+
+            timestamps.append(now)
+
+            # Registration rate limiting (POST to signup/register paths)
+            if (askbot_settings.REGISTRATION_RATE_LIMIT_ENABLED
+                    and request.method == 'POST'
+                    and any(request.path.endswith(s)
+                            for s in _REGISTRATION_SUFFIXES)):
+                reg_window = askbot_settings.REGISTRATION_RATE_LIMIT_WINDOW_SECONDS
+                reg_max = askbot_settings.REGISTRATION_RATE_LIMIT_PER_IP
+                reg_now = now
+
+                reg_timestamps = _registration_log.get(ip)
+                if reg_timestamps is None:
+                    reg_timestamps = collections.deque()
+                    _registration_log[ip] = reg_timestamps
+
+                reg_cutoff = reg_now - reg_window
+                while reg_timestamps and reg_timestamps[0] < reg_cutoff:
+                    reg_timestamps.popleft()
+
+                if len(reg_timestamps) >= reg_max:
+                    return HttpResponse(
+                        'Too many registrations. Please try again later.',
+                        status=429,
+                        content_type='text/plain'
+                    )
+
+                reg_timestamps.append(reg_now)
+
+        return self.get_response(request)

--- a/askbot/setup_templates/settings.py.jinja2
+++ b/askbot/setup_templates/settings.py.jinja2
@@ -142,6 +142,7 @@ MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
 
+    'askbot.middleware.ratelimit.RateLimitMiddleware',
     'askbot.middleware.analytics_session.AnalyticsSessionMiddleware',
     'askbot.middleware.head_request.HeadRequestMiddleware',
     'askbot.middleware.anon_user.ConnectToSessionMessagesMiddleware',

--- a/askbot/tests/test_rate_limiting.py
+++ b/askbot/tests/test_rate_limiting.py
@@ -1,0 +1,448 @@
+"""Tests for per-IP rate limiting middleware, registration rate limiting,
+and content velocity limiting."""
+import time
+from unittest.mock import patch
+
+from django.test import TestCase, RequestFactory
+
+from askbot.tests.utils import AskbotTestCase, with_settings
+from askbot.middleware.ratelimit import (
+    RateLimitMiddleware, _request_log, _registration_log, _lock
+)
+
+
+def _clear_rate_limit_state():
+    """Clear the module-level rate limit tracking dicts."""
+    with _lock:
+        _request_log.clear()
+        _registration_log.clear()
+
+
+class RateLimitMiddlewareTests(TestCase):
+    """Tests for the per-IP rate limiting middleware."""
+
+    def setUp(self):
+        _clear_rate_limit_state()
+        self.factory = RequestFactory()
+        self.get_response = lambda request: type(
+            'Response', (), {'status_code': 200}
+        )()
+        self.middleware = RateLimitMiddleware(self.get_response)
+
+    def tearDown(self):
+        _clear_rate_limit_state()
+
+    @with_settings(
+        RATE_LIMIT_ENABLED=True,
+        RATE_LIMIT_REQUESTS_PER_WINDOW=5,
+        RATE_LIMIT_WINDOW_SECONDS=60,
+        RATE_LIMIT_CACHE_SIZE=1000,
+        RATE_LIMIT_BAN_ENABLED=False,
+    )
+    def test_allows_requests_under_limit(self):
+        for i in range(5):
+            request = self.factory.get('/')
+            request.META['REMOTE_ADDR'] = '1.2.3.4'
+            response = self.middleware(request)
+            self.assertEqual(response.status_code, 200,
+                             'Request %d should be allowed' % (i + 1))
+
+    @with_settings(
+        RATE_LIMIT_ENABLED=True,
+        RATE_LIMIT_REQUESTS_PER_WINDOW=5,
+        RATE_LIMIT_WINDOW_SECONDS=60,
+        RATE_LIMIT_CACHE_SIZE=1000,
+        RATE_LIMIT_BAN_ENABLED=False,
+    )
+    def test_blocks_requests_over_limit(self):
+        for i in range(5):
+            request = self.factory.get('/')
+            request.META['REMOTE_ADDR'] = '1.2.3.4'
+            self.middleware(request)
+
+        # 6th request should be rate limited
+        request = self.factory.get('/')
+        request.META['REMOTE_ADDR'] = '1.2.3.4'
+        response = self.middleware(request)
+        self.assertEqual(response.status_code, 429)
+
+    @with_settings(
+        RATE_LIMIT_ENABLED=True,
+        RATE_LIMIT_REQUESTS_PER_WINDOW=2,
+        RATE_LIMIT_WINDOW_SECONDS=60,
+        RATE_LIMIT_CACHE_SIZE=1000,
+        RATE_LIMIT_BAN_ENABLED=False,
+    )
+    def test_x_forwarded_for_used(self):
+        """Rate limiter should use X-Forwarded-For header when present."""
+        for i in range(2):
+            request = self.factory.get('/')
+            request.META['REMOTE_ADDR'] = '127.0.0.1'
+            request.META['HTTP_X_FORWARDED_FOR'] = '10.0.0.1'
+            self.middleware(request)
+
+        # 3rd request from same forwarded IP should be blocked
+        request = self.factory.get('/')
+        request.META['REMOTE_ADDR'] = '127.0.0.1'
+        request.META['HTTP_X_FORWARDED_FOR'] = '10.0.0.1'
+        response = self.middleware(request)
+        self.assertEqual(response.status_code, 429)
+
+        # But a request from 127.0.0.1 without forwarded header should pass
+        request = self.factory.get('/')
+        request.META['REMOTE_ADDR'] = '127.0.0.1'
+        response = self.middleware(request)
+        self.assertEqual(response.status_code, 200)
+
+    @with_settings(
+        RATE_LIMIT_ENABLED=True,
+        RATE_LIMIT_REQUESTS_PER_WINDOW=2,
+        RATE_LIMIT_WINDOW_SECONDS=60,
+        RATE_LIMIT_CACHE_SIZE=1000,
+        RATE_LIMIT_BAN_ENABLED=False,
+    )
+    def test_x_forwarded_for_multiple_uses_first(self):
+        """When X-Forwarded-For has multiple IPs, use the first one."""
+        for i in range(2):
+            request = self.factory.get('/')
+            request.META['REMOTE_ADDR'] = '127.0.0.1'
+            request.META['HTTP_X_FORWARDED_FOR'] = '10.0.0.1, 10.0.0.2, 10.0.0.3'
+            self.middleware(request)
+
+        # 3rd request from same first forwarded IP should be blocked
+        request = self.factory.get('/')
+        request.META['REMOTE_ADDR'] = '127.0.0.1'
+        request.META['HTTP_X_FORWARDED_FOR'] = '10.0.0.1, 10.0.0.2'
+        response = self.middleware(request)
+        self.assertEqual(response.status_code, 429)
+
+    @with_settings(
+        RATE_LIMIT_ENABLED=True,
+        RATE_LIMIT_REQUESTS_PER_WINDOW=2,
+        RATE_LIMIT_WINDOW_SECONDS=60,
+        RATE_LIMIT_CACHE_SIZE=1000,
+        RATE_LIMIT_BAN_ENABLED=False,
+    )
+    def test_empty_x_forwarded_for_fallback(self):
+        """Empty X-Forwarded-For should fall back to REMOTE_ADDR."""
+        for i in range(2):
+            request = self.factory.get('/')
+            request.META['REMOTE_ADDR'] = '1.2.3.4'
+            request.META['HTTP_X_FORWARDED_FOR'] = ''
+            self.middleware(request)
+
+        # Should be blocked by REMOTE_ADDR
+        request = self.factory.get('/')
+        request.META['REMOTE_ADDR'] = '1.2.3.4'
+        request.META['HTTP_X_FORWARDED_FOR'] = ''
+        response = self.middleware(request)
+        self.assertEqual(response.status_code, 429)
+
+    @with_settings(
+        RATE_LIMIT_ENABLED=True,
+        RATE_LIMIT_REQUESTS_PER_WINDOW=5,
+        RATE_LIMIT_WINDOW_SECONDS=60,
+        RATE_LIMIT_CACHE_SIZE=1000,
+        RATE_LIMIT_BAN_ENABLED=False,
+    )
+    def test_different_ips_tracked_separately(self):
+        for i in range(5):
+            request = self.factory.get('/')
+            request.META['REMOTE_ADDR'] = '1.2.3.4'
+            self.middleware(request)
+
+        # Different IP should still be allowed
+        request = self.factory.get('/')
+        request.META['REMOTE_ADDR'] = '5.6.7.8'
+        response = self.middleware(request)
+        self.assertEqual(response.status_code, 200)
+
+    @with_settings(
+        RATE_LIMIT_ENABLED=True,
+        RATE_LIMIT_REQUESTS_PER_WINDOW=5,
+        RATE_LIMIT_WINDOW_SECONDS=60,
+        RATE_LIMIT_CACHE_SIZE=1000,
+        RATE_LIMIT_BAN_ENABLED=False,
+    )
+    def test_sets_ratelimited_attribute(self):
+        for i in range(5):
+            request = self.factory.get('/')
+            request.META['REMOTE_ADDR'] = '1.2.3.4'
+            self.middleware(request)
+
+        request = self.factory.get('/')
+        request.META['REMOTE_ADDR'] = '1.2.3.4'
+        self.middleware(request)
+        self.assertTrue(getattr(request, '_ratelimited', False))
+
+    @with_settings(RATE_LIMIT_ENABLED=False)
+    def test_disabled_allows_all(self):
+        for i in range(200):
+            request = self.factory.get('/')
+            request.META['REMOTE_ADDR'] = '1.2.3.4'
+            response = self.middleware(request)
+            self.assertEqual(response.status_code, 200)
+
+    @with_settings(
+        RATE_LIMIT_ENABLED=True,
+        RATE_LIMIT_REQUESTS_PER_WINDOW=2,
+        RATE_LIMIT_WINDOW_SECONDS=1,
+        RATE_LIMIT_CACHE_SIZE=1000,
+        RATE_LIMIT_BAN_ENABLED=False,
+    )
+    def test_window_expiry_resets_count(self):
+        for i in range(2):
+            request = self.factory.get('/')
+            request.META['REMOTE_ADDR'] = '1.2.3.4'
+            self.middleware(request)
+
+        # Should be blocked now
+        request = self.factory.get('/')
+        request.META['REMOTE_ADDR'] = '1.2.3.4'
+        response = self.middleware(request)
+        self.assertEqual(response.status_code, 429)
+
+        # Wait for window to expire
+        time.sleep(1.1)
+
+        # Should be allowed again
+        request = self.factory.get('/')
+        request.META['REMOTE_ADDR'] = '1.2.3.4'
+        response = self.middleware(request)
+        self.assertEqual(response.status_code, 200)
+
+
+class RateLimitWhitelistTests(TestCase):
+    """Tests for ASKBOT_INTERNAL_IPS whitelist bypass."""
+
+    def setUp(self):
+        _clear_rate_limit_state()
+        self.factory = RequestFactory()
+        self.get_response = lambda request: type(
+            'Response', (), {'status_code': 200}
+        )()
+        self.middleware = RateLimitMiddleware(self.get_response)
+
+    def tearDown(self):
+        _clear_rate_limit_state()
+
+    @with_settings(
+        RATE_LIMIT_ENABLED=True,
+        RATE_LIMIT_REQUESTS_PER_WINDOW=2,
+        RATE_LIMIT_WINDOW_SECONDS=60,
+        RATE_LIMIT_CACHE_SIZE=1000,
+        RATE_LIMIT_BAN_ENABLED=False,
+    )
+    def test_whitelisted_ip_bypasses_limit(self):
+        with self.settings(ASKBOT_INTERNAL_IPS=['10.0.0.1']):
+            for i in range(10):
+                request = self.factory.get('/')
+                request.META['REMOTE_ADDR'] = '10.0.0.1'
+                response = self.middleware(request)
+                self.assertEqual(response.status_code, 200)
+
+
+class RegistrationRateLimitTests(TestCase):
+    """Tests for per-IP registration rate limiting."""
+
+    def setUp(self):
+        _clear_rate_limit_state()
+        self.factory = RequestFactory()
+        self.get_response = lambda request: type(
+            'Response', (), {'status_code': 200}
+        )()
+        self.middleware = RateLimitMiddleware(self.get_response)
+
+    def tearDown(self):
+        _clear_rate_limit_state()
+
+    @with_settings(
+        RATE_LIMIT_ENABLED=True,
+        RATE_LIMIT_REQUESTS_PER_WINDOW=100,
+        RATE_LIMIT_WINDOW_SECONDS=60,
+        RATE_LIMIT_CACHE_SIZE=1000,
+        RATE_LIMIT_BAN_ENABLED=False,
+        REGISTRATION_RATE_LIMIT_ENABLED=True,
+        REGISTRATION_RATE_LIMIT_PER_IP=3,
+        REGISTRATION_RATE_LIMIT_WINDOW_SECONDS=86400,
+    )
+    def test_allows_registrations_under_limit(self):
+        for i in range(3):
+            request = self.factory.post('/account/signup/')
+            request.META['REMOTE_ADDR'] = '1.2.3.4'
+            response = self.middleware(request)
+            self.assertEqual(response.status_code, 200,
+                             'Registration %d should be allowed' % (i + 1))
+
+    @with_settings(
+        RATE_LIMIT_ENABLED=True,
+        RATE_LIMIT_REQUESTS_PER_WINDOW=100,
+        RATE_LIMIT_WINDOW_SECONDS=60,
+        RATE_LIMIT_CACHE_SIZE=1000,
+        RATE_LIMIT_BAN_ENABLED=False,
+        REGISTRATION_RATE_LIMIT_ENABLED=True,
+        REGISTRATION_RATE_LIMIT_PER_IP=3,
+        REGISTRATION_RATE_LIMIT_WINDOW_SECONDS=86400,
+    )
+    def test_blocks_registrations_over_limit(self):
+        for i in range(3):
+            request = self.factory.post('/account/signup/')
+            request.META['REMOTE_ADDR'] = '1.2.3.4'
+            self.middleware(request)
+
+        # 4th registration should be blocked
+        request = self.factory.post('/account/signup/')
+        request.META['REMOTE_ADDR'] = '1.2.3.4'
+        response = self.middleware(request)
+        self.assertEqual(response.status_code, 429)
+
+    @with_settings(
+        RATE_LIMIT_ENABLED=True,
+        RATE_LIMIT_REQUESTS_PER_WINDOW=100,
+        RATE_LIMIT_WINDOW_SECONDS=60,
+        RATE_LIMIT_CACHE_SIZE=1000,
+        RATE_LIMIT_BAN_ENABLED=False,
+        REGISTRATION_RATE_LIMIT_ENABLED=True,
+        REGISTRATION_RATE_LIMIT_PER_IP=3,
+        REGISTRATION_RATE_LIMIT_WINDOW_SECONDS=86400,
+    )
+    def test_get_requests_not_counted(self):
+        """GET requests to signup should not count toward registration limit."""
+        for i in range(5):
+            request = self.factory.get('/account/signup/')
+            request.META['REMOTE_ADDR'] = '1.2.3.4'
+            response = self.middleware(request)
+            self.assertEqual(response.status_code, 200)
+
+    @with_settings(
+        RATE_LIMIT_ENABLED=True,
+        RATE_LIMIT_REQUESTS_PER_WINDOW=100,
+        RATE_LIMIT_WINDOW_SECONDS=60,
+        RATE_LIMIT_CACHE_SIZE=1000,
+        RATE_LIMIT_BAN_ENABLED=False,
+        REGISTRATION_RATE_LIMIT_ENABLED=True,
+        REGISTRATION_RATE_LIMIT_PER_IP=3,
+        REGISTRATION_RATE_LIMIT_WINDOW_SECONDS=86400,
+    )
+    def test_different_ips_tracked_separately(self):
+        for i in range(3):
+            request = self.factory.post('/account/signup/')
+            request.META['REMOTE_ADDR'] = '1.2.3.4'
+            self.middleware(request)
+
+        # Different IP should still be allowed
+        request = self.factory.post('/account/signup/')
+        request.META['REMOTE_ADDR'] = '5.6.7.8'
+        response = self.middleware(request)
+        self.assertEqual(response.status_code, 200)
+
+    @with_settings(
+        RATE_LIMIT_ENABLED=True,
+        RATE_LIMIT_REQUESTS_PER_WINDOW=100,
+        RATE_LIMIT_WINDOW_SECONDS=60,
+        RATE_LIMIT_CACHE_SIZE=1000,
+        RATE_LIMIT_BAN_ENABLED=False,
+        REGISTRATION_RATE_LIMIT_ENABLED=False,
+        REGISTRATION_RATE_LIMIT_PER_IP=3,
+        REGISTRATION_RATE_LIMIT_WINDOW_SECONDS=86400,
+    )
+    def test_disabled_allows_all(self):
+        for i in range(10):
+            request = self.factory.post('/account/signup/')
+            request.META['REMOTE_ADDR'] = '1.2.3.4'
+            response = self.middleware(request)
+            self.assertEqual(response.status_code, 200)
+
+    @with_settings(
+        RATE_LIMIT_ENABLED=True,
+        RATE_LIMIT_REQUESTS_PER_WINDOW=100,
+        RATE_LIMIT_WINDOW_SECONDS=60,
+        RATE_LIMIT_CACHE_SIZE=1000,
+        RATE_LIMIT_BAN_ENABLED=False,
+        REGISTRATION_RATE_LIMIT_ENABLED=True,
+        REGISTRATION_RATE_LIMIT_PER_IP=3,
+        REGISTRATION_RATE_LIMIT_WINDOW_SECONDS=86400,
+    )
+    def test_register_path_also_matched(self):
+        """The /account/register/ path should also be rate limited."""
+        for i in range(3):
+            request = self.factory.post('/account/register/')
+            request.META['REMOTE_ADDR'] = '1.2.3.4'
+            self.middleware(request)
+
+        request = self.factory.post('/account/register/')
+        request.META['REMOTE_ADDR'] = '1.2.3.4'
+        response = self.middleware(request)
+        self.assertEqual(response.status_code, 429)
+
+
+class ContentVelocityTests(AskbotTestCase):
+    """Tests for content velocity limiting of watched users."""
+
+    def setUp(self):
+        self.watched_user = self.create_user('watched_user', status='w')
+        self.approved_user = self.create_user('approved_user', status='a')
+
+    @with_settings(
+        CONTENT_VELOCITY_ENABLED=True,
+        CONTENT_VELOCITY_MAX_POSTS=3,
+        CONTENT_VELOCITY_WINDOW_MINUTES=60,
+    )
+    def test_watched_user_blocked_over_limit(self):
+        from askbot.views.writers import _check_content_velocity
+        from django.core import exceptions as django_exceptions
+
+        # Create posts for the watched user
+        for i in range(3):
+            self.post_question(user=self.watched_user,
+                               title='question %d' % i)
+
+        with self.assertRaises(django_exceptions.PermissionDenied):
+            _check_content_velocity(self.watched_user)
+
+    @with_settings(
+        CONTENT_VELOCITY_ENABLED=True,
+        CONTENT_VELOCITY_MAX_POSTS=5,
+        CONTENT_VELOCITY_WINDOW_MINUTES=60,
+    )
+    def test_watched_user_allowed_under_limit(self):
+        from askbot.views.writers import _check_content_velocity
+
+        # Create fewer posts than the limit
+        for i in range(3):
+            self.post_question(user=self.watched_user,
+                               title='question %d' % i)
+
+        # Should not raise
+        _check_content_velocity(self.watched_user)
+
+    @with_settings(
+        CONTENT_VELOCITY_ENABLED=True,
+        CONTENT_VELOCITY_MAX_POSTS=3,
+        CONTENT_VELOCITY_WINDOW_MINUTES=60,
+    )
+    def test_approved_user_not_affected(self):
+        from askbot.views.writers import _check_content_velocity
+
+        # Create many posts for the approved user
+        for i in range(5):
+            self.post_question(user=self.approved_user,
+                               title='question %d' % i)
+
+        # Should not raise — approved users are not watched
+        _check_content_velocity(self.approved_user)
+
+    @with_settings(
+        CONTENT_VELOCITY_ENABLED=False,
+        CONTENT_VELOCITY_MAX_POSTS=3,
+        CONTENT_VELOCITY_WINDOW_MINUTES=60,
+    )
+    def test_disabled_allows_all(self):
+        from askbot.views.writers import _check_content_velocity
+
+        for i in range(10):
+            self.post_question(user=self.watched_user,
+                               title='question %d' % i)
+
+        # Should not raise when disabled
+        _check_content_velocity(self.watched_user)

--- a/askbot/views/writers.py
+++ b/askbot/views/writers.py
@@ -4,6 +4,7 @@
 
 This module contains views that allow adding, editing, and deleting main textual content.
 """
+import datetime
 import logging
 import os
 import os.path
@@ -50,6 +51,32 @@ from askbot.templatetags import extra_filters_jinja as template_filters
 from askbot.importers.stackexchange import management as stackexchange#todo: may change
 from askbot.utils.slug import slugify
 from askbot import spam_checker
+
+
+def _check_content_velocity(user):
+    """Enforce post rate limit for watched users.
+
+    Raises PermissionDenied if the user has exceeded the content
+    velocity limit within the configured window.
+    """
+    if not askbot_settings.CONTENT_VELOCITY_ENABLED:
+        return
+    if not user.is_watched():
+        return
+
+    window_minutes = askbot_settings.CONTENT_VELOCITY_WINDOW_MINUTES
+    max_posts = askbot_settings.CONTENT_VELOCITY_MAX_POSTS
+    cutoff = timezone.now() - datetime.timedelta(minutes=window_minutes)
+    recent_count = models.Post.objects.filter(
+        author=user,
+        added_at__gte=cutoff,
+        deleted=False
+    ).count()
+    if recent_count >= max_posts:
+        raise exceptions.PermissionDenied(
+            _('You are posting too quickly. Please wait a while before posting again.')
+        )
+
 
 #todo: make this work with csrf
 @csrf.csrf_exempt
@@ -247,6 +274,7 @@ def ask(request):#view used to ask a new question
 
             if user:
                 try:
+                    _check_content_velocity(user)
                     question = user.post_question(
                         title=title,
                         body_text=text,
@@ -529,6 +557,7 @@ def answer(request, id, form_class=forms.AnswerForm):#process a new answer
                 user = form.get_post_user(request.user)
                 try:
                     text = form.cleaned_data['text']
+                    _check_content_velocity(user)
                     spam_checker_params = spam_checker.get_params_from_request(request)
                     enabled = askbot_settings.SPAM_FILTER_ENABLED
                     if enabled and spam_checker.is_spam(text, **spam_checker_params):
@@ -678,6 +707,7 @@ def post_comments(request):#generic ajax handler to load comments to an object
                 raise exceptions.PermissionDenied(askbot_settings.READ_ONLY_MESSAGE)
 
             text = form.cleaned_data['comment']
+            _check_content_velocity(user)
             spam_checker_params = spam_checker.get_params_from_request(request)
             enabled = askbot_settings.SPAM_FILTER_ENABLED
             if enabled and spam_checker.is_spam(text, **spam_checker_params):


### PR DESCRIPTION
Sliding-window per-IP rate limiter with livesettings configuration:
- Configurable requests/window, cache size, optional ban command
- Uses X-Forwarded-For for correct IP detection behind reverse proxies
- ASKBOT_INTERNAL_IPS whitelist bypasses rate limiting
- Per-IP registration rate limiting on signup/register endpoints
- Content velocity limiting for watched users (opt-in, default off)

Rate-limited requests get a _ratelimited attribute for integration with the request logging middleware.