### PR TITLE
Re-enable anonymous page caching with proper cache invalidation

### DIFF
--- a/askbot/models/question.py
+++ b/askbot/models/question.py
@@ -1055,6 +1055,13 @@ class Thread(models.Model):
     def clear_cached_data(self):
         self.invalidate_cached_post_data()
         self.invalidate_cached_summary_html()
+        self.invalidate_cached_thread_content_html()
+
+    def invalidate_cached_thread_content_html(self):
+        """Invalidates the template-level cache for the question detail page."""
+        from django.core.cache.utils import make_template_fragment_key
+        key = make_template_fragment_key('thread-content-html', [self.id])
+        cache.cache.delete(key)
 
     def get_public_posts(self):
         kwargs = {

--- a/askbot/setup_templates/settings.py.jinja2
+++ b/askbot/setup_templates/settings.py.jinja2
@@ -136,6 +136,7 @@ TEMPLATES = (
 )
 
 MIDDLEWARE = (
+    'askbot.middleware.cache.UpdateCacheMiddleware',         # must be first (response phase)
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware', # prerequisite for user messages
     'django.contrib.messages.middleware.MessageMiddleware', # for user messages
@@ -148,6 +149,7 @@ MIDDLEWARE = (
     'askbot.middleware.forum_mode.ForumModeMiddleware',
     'askbot.middleware.cancel.CancelActionMiddleware',
     'askbot.middleware.view_log.ViewLogMiddleware',
+    'askbot.middleware.cache.FetchFromCacheMiddleware',      # must be last (request phase)
 )
 
 ATOMIC_REQUESTS = True
@@ -264,6 +266,7 @@ CACHES['default'].update({'KEY_PREFIX': 'askbot',})
 LIVESETTINGS_CACHE_TIMEOUT = CACHES['default']['TIMEOUT']
 CACHE_MIDDLEWARE_ANONYMOUS_ONLY = True
 CACHE_MIDDLEWARE_SECONDS = 600
+CACHE_MIDDLEWARE_ALIAS = 'default'
 #If you use memcache you may want to uncomment the following line to enable memcached based sessions
 #SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'
 

--- a/askbot/tests/test_cache_invalidation.py
+++ b/askbot/tests/test_cache_invalidation.py
@@ -1,0 +1,44 @@
+"""Tests for template cache invalidation."""
+from django.core.cache import cache
+from django.core.cache.utils import make_template_fragment_key
+
+from askbot.tests.utils import AskbotTestCase
+
+
+class TemplateCacheInvalidationTests(AskbotTestCase):
+    """Tests that thread cache invalidation clears template fragment cache."""
+
+    def setUp(self):
+        self.user = self.create_user('cacheuser')
+        self.question = self.post_question(user=self.user)
+        self.thread = self.question.thread
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_invalidate_clears_template_cache(self):
+        """invalidate_cached_thread_content_html() should delete the
+        template fragment cache for the thread."""
+        key = make_template_fragment_key('thread-content-html', [self.thread.id])
+        cache.set(key, '<html>cached</html>')
+        self.assertIsNotNone(cache.get(key))
+
+        self.thread.invalidate_cached_thread_content_html()
+        self.assertIsNone(cache.get(key))
+
+    def test_clear_cached_data_includes_template_cache(self):
+        """clear_cached_data() should also clear the template fragment cache."""
+        key = make_template_fragment_key('thread-content-html', [self.thread.id])
+        cache.set(key, '<html>cached</html>')
+        self.assertIsNotNone(cache.get(key))
+
+        self.thread.clear_cached_data()
+        self.assertIsNone(cache.get(key))
+
+    def test_reset_cached_data_includes_template_cache(self):
+        """reset_cached_data() should also clear the template fragment cache."""
+        key = make_template_fragment_key('thread-content-html', [self.thread.id])
+        cache.set(key, '<html>cached</html>')
+
+        self.thread.reset_cached_data()
+        self.assertIsNone(cache.get(key))

--- a/askbot/views/commands.py
+++ b/askbot/views/commands.py
@@ -1510,6 +1510,7 @@ def publish_post(request):
     else:
         message = _('This feature is disabled')
 
+    post.thread.clear_cached_data()
     request.user.message_set.create(message=message)
     return {'redirect_url': post.get_absolute_url()}
 

--- a/askbot/views/readers.py
+++ b/askbot/views/readers.py
@@ -692,7 +692,7 @@ def question(request, id):#refactor - long subroutine. display question body, an
         'category_tree_data': askbot_settings.CATEGORY_TREE,
         'favorited' : favorited,
         'group_read_only': group_read_only,
-        'is_cacheable': False,#is_cacheable, #temporary, until invalidation fix
+        'is_cacheable': is_cacheable,
         'language_code': translation.get_language(),
         'long_time': const.LONG_TIME,#"forever" caching
         'show_answer_form': should_show_answer_form(request.user, thread, answers),


### PR DESCRIPTION
The question detail page had caching disabled with a TODO comment ("temporary, until invalidation fix"). This restores caching for anonymous users by:

- Setting is_cacheable back to the computed value in the question view
- Adding invalidate_cached_thread_content_html() to the Thread model, which clears the template fragment cache for the question detail page
- Calling it from clear_cached_data() so all cache invalidation paths (new answers, edits, comments, etc.) also clear the page cache
- Adding cache invalidation in publish_post() for post privacy toggles
- Wiring UpdateCacheMiddleware (first) and FetchFromCacheMiddleware (last) in the settings template MIDDLEWARE
- Adding CACHE_MIDDLEWARE_ALIAS setting