### PR TITLE
Add access control modes for API v1 endpoints

### DIFF
--- a/askbot/conf/__init__.py
+++ b/askbot/conf/__init__.py
@@ -33,6 +33,7 @@ def init():
     import askbot.conf.access_control
     import askbot.conf.site_modes
     import askbot.conf.words
+    import askbot.conf.api_settings
 
 #import main settings object
 from askbot.conf.settings_wrapper import settings

--- a/askbot/conf/api_settings.py
+++ b/askbot/conf/api_settings.py
@@ -1,0 +1,32 @@
+"""API access control livesettings configuration."""
+from askbot.conf.settings_wrapper import settings
+from askbot.conf.super_groups import EXTERNAL_SERVICES
+from livesettings import values as livesettings
+from django.utils.translation import gettext_lazy as _
+
+API_SETTINGS = livesettings.ConfigurationGroup(
+    'API_SETTINGS',
+    _('API access control'),
+    super_group=EXTERNAL_SERVICES
+)
+
+settings.register(
+    livesettings.StringValue(
+        API_SETTINGS,
+        'API_V1_ACCESS_MODE',
+        description=_('API v1 access mode'),
+        default='public',
+        choices=(
+            ('public', _('Public (anyone can access)')),
+            ('authenticated', _('Authenticated (login required)')),
+            ('disabled', _('Disabled (moderator item lookups only)')),
+        ),
+        help_text=_(
+            'Controls who can access the /api/v1/ endpoints. '
+            '"Authenticated" requires login for all API access. '
+            '"Disabled" blocks list endpoints entirely and allows '
+            'only individual item lookups for moderators/admins '
+            '(preserves merge dialog functionality).'
+        )
+    )
+)

--- a/askbot/tests/test_api_access_control.py
+++ b/askbot/tests/test_api_access_control.py
@@ -1,0 +1,63 @@
+"""Tests for API v1 access control modes."""
+from django.test import TestCase
+from django.urls import reverse
+
+from askbot.tests.utils import AskbotTestCase, with_settings
+
+
+class ApiAccessControlTests(AskbotTestCase):
+    """Tests for API v1 access control modes."""
+
+    def setUp(self):
+        self.poster = self.create_user('poster')
+        self.user = self.create_user('testuser')
+        self.mod = self.create_user('testmod', status='m')
+        self.question = self.post_question(user=self.poster)
+
+    @with_settings(API_V1_ACCESS_MODE='public')
+    def test_public_mode_allows_anonymous(self):
+        response = self.client.get(reverse('api_v1_info'))
+        self.assertEqual(response.status_code, 200)
+
+    @with_settings(API_V1_ACCESS_MODE='authenticated')
+    def test_authenticated_mode_blocks_anonymous(self):
+        response = self.client.get(reverse('api_v1_info'))
+        self.assertEqual(response.status_code, 403)
+
+    @with_settings(API_V1_ACCESS_MODE='authenticated')
+    def test_authenticated_mode_allows_logged_in(self):
+        self.client.force_login(self.user)
+        response = self.client.get(reverse('api_v1_info'))
+        self.assertEqual(response.status_code, 200)
+
+    @with_settings(API_V1_ACCESS_MODE='disabled')
+    def test_disabled_mode_blocks_list_endpoints(self):
+        """List endpoints return 404 for everyone, even moderators."""
+        self.client.force_login(self.mod)
+        for url_name in ('api_v1_info', 'api_v1_users', 'api_v1_questions'):
+            response = self.client.get(reverse(url_name))
+            self.assertEqual(response.status_code, 404,
+                             '%s should be blocked in disabled mode' % url_name)
+
+    @with_settings(API_V1_ACCESS_MODE='disabled')
+    def test_disabled_mode_blocks_regular_user_item_endpoints(self):
+        self.client.force_login(self.user)
+        response = self.client.get(
+            reverse('api_v1_question', kwargs={'question_id': self.question.id})
+        )
+        self.assertEqual(response.status_code, 404)
+
+    @with_settings(API_V1_ACCESS_MODE='disabled')
+    def test_disabled_mode_allows_moderator_item_endpoints(self):
+        self.client.force_login(self.mod)
+        response = self.client.get(
+            reverse('api_v1_question', kwargs={'question_id': self.question.id})
+        )
+        self.assertEqual(response.status_code, 200)
+
+    @with_settings(API_V1_ACCESS_MODE='disabled')
+    def test_disabled_mode_blocks_anonymous_item_endpoints(self):
+        response = self.client.get(
+            reverse('api_v1_question', kwargs={'question_id': self.question.id})
+        )
+        self.assertEqual(response.status_code, 404)

--- a/askbot/views/api_v1.py
+++ b/askbot/views/api_v1.py
@@ -1,14 +1,59 @@
 """/api/v1 views"""
+import functools
 import json
 from django.core.paginator import Paginator, EmptyPage, InvalidPage
 from django.shortcuts import get_object_or_404
-from django.http import HttpResponse, Http404
+from django.http import HttpResponse, Http404, JsonResponse
 from askbot import models
 from askbot.models import User, UserProfile
 from askbot.conf import settings as askbot_settings
 from askbot.search.state_manager import SearchState
 from askbot.utils.html import site_url
 from askbot.utils.functions import get_epoch_str
+
+
+def _check_api_access(is_list_endpoint=False):
+    """Decorator that enforces API_V1_ACCESS_MODE setting.
+
+    is_list_endpoint: if True, this endpoint is blocked in 'disabled' mode
+    even for moderators.
+    """
+    def decorator(view_func):
+        @functools.wraps(view_func)
+        def wrapper(request, *args, **kwargs):
+            mode = askbot_settings.API_V1_ACCESS_MODE
+            if mode == 'public':
+                return view_func(request, *args, **kwargs)
+
+            is_authenticated = (hasattr(request, 'user')
+                                and request.user.is_authenticated)
+            is_mod = (is_authenticated
+                      and request.user.is_administrator_or_moderator())
+
+            if mode == 'authenticated':
+                if not is_authenticated:
+                    return JsonResponse(
+                        {'error': 'Authentication required'},
+                        status=403
+                    )
+                return view_func(request, *args, **kwargs)
+
+            if mode == 'disabled':
+                if is_list_endpoint:
+                    return JsonResponse(
+                        {'error': 'Endpoint disabled'},
+                        status=404
+                    )
+                if not is_mod:
+                    return JsonResponse(
+                        {'error': 'API disabled'},
+                        status=404
+                    )
+                return view_func(request, *args, **kwargs)
+
+            return view_func(request, *args, **kwargs)
+        return wrapper
+    return decorator
 
 def get_posts_filter(posts_filter=None):
     """Returns filter for the posts.
@@ -95,6 +140,7 @@ def get_answer_data(post):
 
     return datum
 
+@_check_api_access(is_list_endpoint=True)
 def info(request): #pylint: disable=unused-argument
     """Returns general data about the forum"""
     data = {}
@@ -114,6 +160,7 @@ def info(request): #pylint: disable=unused-argument
     json_string = json.dumps(data)
     return HttpResponse(json_string, content_type='application/json')
 
+@_check_api_access(is_list_endpoint=False)
 def user(request, user_id): #pylint: disable=unused-argument
     '''
        Returns data about one user
@@ -129,6 +176,7 @@ def user(request, user_id): #pylint: disable=unused-argument
     return HttpResponse(json_string, content_type='application/json')
 
 
+@_check_api_access(is_list_endpoint=True)
 def users(request):
     """Returns data of the most active or latest users."""
     page = request.GET.get("page", '1')
@@ -166,6 +214,7 @@ def users(request):
     return HttpResponse(json_string, content_type='application/json')
 
 
+@_check_api_access(is_list_endpoint=False)
 def question(request, question_id): #pylint: disable=unused-argument
     """Returns info about a question by id"""
     #we retrieve question by post id, b/c that's what is in the url,
@@ -176,6 +225,7 @@ def question(request, question_id): #pylint: disable=unused-argument
     json_string = json.dumps(datum)
     return HttpResponse(json_string, content_type='application/json')
 
+@_check_api_access(is_list_endpoint=False)
 def answer(request, answer_id): #pylint: disable=unused-argument
     """Returns info about an answer by id"""
     post_filter = get_posts_filter({'id': answer_id, 'post_type': 'answer'})
@@ -184,6 +234,7 @@ def answer(request, answer_id): #pylint: disable=unused-argument
     json_string = json.dumps(datum)
     return HttpResponse(json_string, content_type='application/json')
 
+@_check_api_access(is_list_endpoint=True)
 def questions(request):
     """
     List of Questions, Tagged questions, and Unanswered questions.


### PR DESCRIPTION
Adds a configurable access control decorator to all /api/v1/ views with three modes via livesettings:

- public: original open behavior (default, backwards compatible)
- authenticated: requires login for all API access
- disabled: blocks list endpoints entirely, allows individual item lookups only for moderators/admins (preserves merge dialog)