### PR TITLE
Add email change verification to prevent account takeover

### DIFF
--- a/askbot/conf/user_settings.py
+++ b/askbot/conf/user_settings.py
@@ -65,6 +65,19 @@ settings.register(
 settings.register(
     livesettings.BooleanValue(
         USER_SETTINGS,
+        'EMAIL_CHANGE_REQUIRES_VERIFICATION',
+        default=False,
+        description=_('Require email verification before changing email address'),
+        help_text=_(
+            'When enabled, users must click a confirmation link sent to '
+            'the new email address before the change takes effect.'
+        )
+    )
+)
+
+settings.register(
+    livesettings.BooleanValue(
+        USER_SETTINGS,
         'ALLOW_EMAIL_ADDRESS_IN_USERNAME',
         default=True,
         description=_('Allow email address in user name')

--- a/askbot/jinja2/email/email_change_verification/body.html
+++ b/askbot/jinja2/email/email_change_verification/body.html
@@ -1,0 +1,15 @@
+{% extends "email/base_mail.html"%}
+{% block title %}{% trans %}Confirm your new email address{% endtrans %}{% endblock %}
+{% block headline %}{% trans %}Confirm your new email address{% endtrans %}{% endblock %}
+
+{% block content %}
+<p>{% trans %}You requested to change your email address on {{ site_name }}. Please follow the link below to confirm this change:{% endtrans %}</p>
+
+<p><a href="{{ validation_link }}">{{ validation_link }}</a></p>
+
+<p>{% trans %}If you did not request this change, please ignore this email. Your email address will not be changed.{% endtrans %}</p>
+{% endblock %}
+
+{% block footer %}
+{% include "email/footer.html" %}
+{% endblock %}

--- a/askbot/jinja2/email/email_change_verification/subject.txt
+++ b/askbot/jinja2/email/email_change_verification/subject.txt
@@ -1,0 +1,1 @@
+{% trans %}Confirm your new email address on {{ site_name }}{% endtrans %}

--- a/askbot/mail/messages.py
+++ b/askbot/mail/messages.py
@@ -841,6 +841,22 @@ class ApprovedPostNotificationRespondable(BaseEmail):
 #            'recipient_user': get_user()
 #        }
 
+class EmailChangeVerification(BaseEmail):
+    template_path = 'email/email_change_verification'
+    title = _('Email change verification')
+    description = _('Sent when a user changes their email address, to verify the new address')
+    mock_contexts = ({'key': 'a4umkaeuaousthsth'},)
+
+    def process_context(self, context):
+        context.update({
+            'site_name': askbot_settings.APP_SHORT_NAME,
+            'recipient_user': None,
+            'validation_link': site_url(reverse('verify_email_change')) + \
+                                '?validation_code=' + context['key']
+        })
+        return context
+
+
 class FeedbackEmail(BaseEmail):
     template_path = 'email/feedback'
     title = _('Feedback email')

--- a/askbot/tests/test_email_change.py
+++ b/askbot/tests/test_email_change.py
@@ -1,0 +1,127 @@
+"""Tests for email change verification."""
+import datetime
+from unittest.mock import patch
+
+from django.test import TestCase, RequestFactory
+from django.utils import timezone
+
+from askbot.tests.utils import AskbotTestCase, with_settings
+from askbot.views.users import set_new_email, verify_email_change
+from askbot.deps.django_authopenid.models import UserEmailVerifier
+
+
+class SetNewEmailTests(AskbotTestCase):
+    """Tests for set_new_email()."""
+
+    def setUp(self):
+        self.user = self.create_user('emailuser')
+
+    @with_settings(EMAIL_CHANGE_REQUIRES_VERIFICATION=True)
+    def test_same_email_noop(self):
+        """Setting email to the same value should do nothing."""
+        original_email = self.user.email
+        count_before = UserEmailVerifier.objects.count()
+        set_new_email(self.user, original_email, nomessage=True)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.email, original_email)
+        self.assertEqual(UserEmailVerifier.objects.count(), count_before)
+
+    @with_settings(EMAIL_CHANGE_REQUIRES_VERIFICATION=False)
+    def test_immediate_change_when_disabled(self):
+        """Without verification, email should change immediately."""
+        set_new_email(self.user, 'new@example.com', nomessage=True)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.email, 'new@example.com')
+        self.assertFalse(self.user.email_isvalid)
+
+    @with_settings(EMAIL_CHANGE_REQUIRES_VERIFICATION=True)
+    @patch('askbot.mail.messages.EmailChangeVerification')
+    def test_verification_when_enabled(self, mock_email_cls):
+        """With verification enabled, email should NOT change yet."""
+        mock_email_cls.return_value.send = lambda recipients: None
+        original_email = self.user.email
+
+        set_new_email(self.user, 'new@example.com', nomessage=True)
+
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.email, original_email)  # unchanged
+        # Verifier should have been created
+        self.assertTrue(UserEmailVerifier.objects.exists())
+
+
+class VerifyEmailChangeTests(AskbotTestCase):
+    """Tests for verify_email_change() view."""
+
+    def setUp(self):
+        self.user = self.create_user('verifyuser')
+        self.factory = RequestFactory()
+
+    def _make_request(self, key=None):
+        url = '/'
+        if key:
+            url = '/?validation_code=' + key
+        request = self.factory.get(url)
+        request.user = self.user
+        return request
+
+    def test_no_key_redirects(self):
+        """Missing validation_code should redirect to index."""
+        request = self._make_request()
+        response = verify_email_change(request)
+        self.assertEqual(response.status_code, 302)
+
+    def test_valid_key_changes_email(self):
+        """Valid key should update email and mark it valid."""
+        from askbot.utils.functions import generate_random_key
+
+        key = generate_random_key()
+        verifier = UserEmailVerifier(key=key)
+        verifier.value = {
+            'user_id': self.user.id,
+            'new_email': 'verified@example.com',
+            'action': 'change_email',
+        }
+        verifier.save()
+
+        request = self._make_request(key=key)
+        response = verify_email_change(request)
+
+        self.assertEqual(response.status_code, 302)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.email, 'verified@example.com')
+        self.assertTrue(self.user.email_isvalid)
+
+        verifier.refresh_from_db()
+        self.assertTrue(verifier.verified)
+
+    def test_invalid_key_error(self):
+        """Invalid key should not change email and should not raise."""
+        original_email = self.user.email
+        request = self._make_request(key='badkey123')
+        response = verify_email_change(request)
+
+        self.assertEqual(response.status_code, 302)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.email, original_email)
+
+    def test_expired_key_error(self):
+        """Expired key should not change email."""
+        from askbot.utils.functions import generate_random_key
+
+        key = generate_random_key()
+        verifier = UserEmailVerifier(key=key)
+        verifier.value = {
+            'user_id': self.user.id,
+            'new_email': 'expired@example.com',
+            'action': 'change_email',
+        }
+        verifier.expires_on = timezone.now() - datetime.timedelta(days=1)
+        verifier.save()
+
+        original_email = self.user.email
+        request = self._make_request(key=key)
+        response = verify_email_change(request)
+
+        self.assertEqual(response.status_code, 302)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.email, original_email)

--- a/askbot/urls.py
+++ b/askbot/urls.py
@@ -641,7 +641,12 @@ urlpatterns = [
     re_path('^api/v1/questions/$', views.api_v1.questions, name='api_v1_questions'),
     re_path('^api/v1/questions/(?P<question_id>\d+)/$', views.api_v1.question, name='api_v1_question'),
     re_path('^api/v1/answers/(?P<answer_id>\d+)/$', views.api_v1.answer, name='api_v1_answer'),
-    re_path('^colors/', views.meta.colors, name='colors')
+    re_path('^colors/', views.meta.colors, name='colors'),
+    service_url(
+        r'^verify-email-change/$',
+        views.users.verify_email_change,
+        name='verify_email_change'
+    ),
 ]
 
 if 'askbot.deps.django_authopenid' in settings.INSTALLED_APPS:

--- a/askbot/views/users.py
+++ b/askbot/views/users.py
@@ -515,10 +515,84 @@ def user_moderate(request, subject, context):
 
 #non-view function
 def set_new_email(user, new_email, nomessage=False):
+    """Change user email, optionally requiring verification first.
+
+    When EMAIL_CHANGE_REQUIRES_VERIFICATION is enabled (via livesettings),
+    a verification link is sent to the new address and the email is NOT
+    changed until the user clicks it. Otherwise, the email is changed
+    immediately (original behavior).
+    """
     if new_email != user.email:
+        if askbot_settings.EMAIL_CHANGE_REQUIRES_VERIFICATION:
+            from askbot.deps.django_authopenid.models import UserEmailVerifier
+            from askbot.mail.messages import EmailChangeVerification
+            from askbot.utils.functions import generate_random_key
+
+            verifier = UserEmailVerifier(key=generate_random_key())
+            verifier.value = {
+                'user_id': user.id,
+                'new_email': new_email,
+                'action': 'change_email',
+            }
+            verifier.save()
+
+            email = EmailChangeVerification({'key': verifier.key})
+            email.send([new_email])
+
+            if not nomessage:
+                user.message_set.create(
+                    message=_('A confirmation email has been sent to %(email)s. '
+                              'Please check your inbox and click the link to '
+                              'complete the email change.') % {'email': new_email}
+                )
+        else:
+            user.email = new_email
+            user.email_isvalid = False
+            user.save()
+
+
+def verify_email_change(request):
+    """Process email change verification link.
+
+    When a user clicks the link sent to their new email address,
+    this view swaps in the new email and marks it as valid.
+    """
+    key = request.GET.get('validation_code') or request.POST.get('validation_code')
+    if not key:
+        return HttpResponseRedirect(reverse('index'))
+
+    from askbot.deps.django_authopenid.models import UserEmailVerifier
+    from django.contrib.auth.models import User
+
+    try:
+        verifier = UserEmailVerifier.objects.get(key=key)
+        assert verifier.verified is False
+        assert verifier.has_expired() is False
+        assert verifier.value.get('action') == 'change_email'
+
+        user_id = verifier.value['user_id']
+        new_email = verifier.value['new_email']
+        user = User.objects.get(id=user_id)
+
         user.email = new_email
-        user.email_isvalid = False
+        user.email_isvalid = True
         user.save()
+
+        verifier.verified = True
+        verifier.save()
+
+        request.user.message_set.create(
+            message=_('Your email address has been updated to %(email)s.') % {
+                'email': new_email
+            }
+        )
+    except Exception:
+        logging.exception('Email change verification failed for key=%s', key)
+        request.user.message_set.create(
+            message=_('Sorry, this email verification link has expired or is invalid.')
+        )
+
+    return HttpResponseRedirect(reverse('index'))
 
 
 def need_to_invalidate_post_caches(user, form):


### PR DESCRIPTION
set_new_email() immediately overwrites user.email with no verification, allowing account takeover via brief session access and accidental email loss from typos. This adds an optional verification step controlled by EMAIL_CHANGE_REQUIRES_VERIFICATION livesetting (default False = original immediate-change behavior).

When enabled, a confirmation link is sent to the new address via UserEmailVerifier. The email change only takes effect when the user clicks the link. Includes verify_email_change view, email templates, and URL routing.