### PR TITLE
Add option to delete blocked spammer accounts instead of just blocking

### DIFF
--- a/askbot/conf/__init__.py
+++ b/askbot/conf/__init__.py
@@ -33,6 +33,7 @@ def init():
     import askbot.conf.access_control
     import askbot.conf.site_modes
     import askbot.conf.words
+    import askbot.conf.moderation_settings
 
 #import main settings object
 from askbot.conf.settings_wrapper import settings

--- a/askbot/conf/moderation_settings.py
+++ b/askbot/conf/moderation_settings.py
@@ -1,0 +1,26 @@
+"""Moderation-related livesettings."""
+from django.utils.translation import gettext_lazy as _
+from livesettings import values as livesettings
+from askbot.conf.settings_wrapper import settings
+from askbot.conf.super_groups import DATA_AND_FORMATTING
+
+MODERATION_SETTINGS = livesettings.ConfigurationGroup(
+    'MODERATION_SETTINGS',
+    _('Moderation settings'),
+    super_group=DATA_AND_FORMATTING
+)
+
+settings.register(
+    livesettings.BooleanValue(
+        MODERATION_SETTINGS,
+        'DELETE_BLOCKED_USERS',
+        description=_('Delete blocked spammer accounts entirely'),
+        help_text=_(
+            'When enabled, blocking a spammer deletes the user account '
+            'along with all their content, preventing accumulation of '
+            'dead accounts. When disabled, the account is kept with '
+            'blocked status (original behavior).'
+        ),
+        default=True
+    )
+)

--- a/askbot/views/moderation.py
+++ b/askbot/views/moderation.py
@@ -324,38 +324,46 @@ def moderate_post_edits(request):
                 cache.save()
 
             #block users and all their content
+            delete_users = askbot_settings.DELETE_BLOCKED_USERS
             users = exclude_admins(users)
             num_users = 0
             for user in users:
-                if user.status != 'b':
-                    user.set_status('b')
-                    num_users += 1
+                num_users += 1
                 #delete all content by the user
                 num_posts += request.user.delete_all_content_authored_by_user(
                                                             user, mark_as_spam=True)
+                if delete_users:
+                    user.delete()
+                elif user.status != 'b':
+                    user.set_status('b')
 
             num_ips = len(ips)
 
         elif 'users' in post_data['items']:
+            delete_users = askbot_settings.DELETE_BLOCKED_USERS
             memo_set = set(memo_set)#evaluate memo_set before deleting content
             editors = exclude_admins(get_editors(memo_set))
             assert request.user not in editors
             num_users = 0
             for editor in editors:
-                #block user
-                if editor.status != 'b':
-                    editor.set_status('b')
-                    num_users += 1
+                num_users += 1
                 #delete all content by the user
                 num_posts += request.user.delete_all_content_authored_by_user(
                                                             editor, mark_as_spam=True)
+                if delete_users:
+                    editor.delete()
+                elif editor.status != 'b':
+                    editor.set_status('b')
 
         if num_ips:
             ips_message = ngettext('%d ip blocked', '%d ips blocked', num_ips) % num_ips
             result['message'] = concat_messages(result['message'], ips_message)
 
         if num_users:
-            users_message = ngettext('%d user blocked', '%d users blocked', num_users) % num_users
+            if askbot_settings.DELETE_BLOCKED_USERS:
+                users_message = ngettext('%d user deleted', '%d users deleted', num_users) % num_users
+            else:
+                users_message = ngettext('%d user blocked', '%d users blocked', num_users) % num_users
             result['message'] = concat_messages(result['message'], users_message)
 
         if num_posts:


### PR DESCRIPTION
When a moderator blocks a spammer, the user account accumulates in the database with blocked status. Over time this creates thousands of dead accounts. This adds a DELETE_BLOCKED_USERS livesetting (default True) that deletes the user account entirely after content deletion, instead of just setting status to blocked.

When disabled, preserves the original set_status('b') behavior. The UI message says "deleted" or "blocked" accordingly.