### PR TITLE
Canonicalize tag URL order: redirect /tags:c,a,b/ -> /tags:a,b,c/

### DIFF
--- a/askbot/search/state_manager.py
+++ b/askbot/search/state_manager.py
@@ -133,6 +133,12 @@ class SearchState(object):
                 tag = t.strip()
                 if tag not in self.tags:
                     self.tags.append(tag)
+            # Canonicalize tag order. Without this, every permutation of the
+            # same tag set produces a distinct URL serving identical results,
+            # which is wasteful (cache fragmentation, duplicate SEO content) and
+            # is exploited by scrapers to bypass per-URL caching by enumerating
+            # the N! orderings of a single tag set.
+            self.tags.sort()
 
         self.author = int(author) if author else None
         self.page = int(page) if page else 1

--- a/askbot/tests/test_canonical_urls.py
+++ b/askbot/tests/test_canonical_urls.py
@@ -1,0 +1,107 @@
+"""Tests for canonical tag-URL handling.
+
+Without canonicalization, every permutation of the same tag set produces a
+distinct URL serving identical content. This fragments caches and is
+exploited by scrapers that enumerate tag orderings to bypass per-URL
+caching. The fix sorts tags alphabetically and 301-redirects unsorted
+tag URLs to the canonical (sorted) form.
+"""
+from django.test import RequestFactory
+from django.contrib.auth.models import AnonymousUser
+
+from askbot.search.state_manager import SearchState
+from askbot.tests.utils import AskbotTestCase
+from askbot.views.readers import questions as questions_view
+
+
+class SearchStateTagSortingTests(AskbotTestCase):
+    """SearchState should normalize tag order on construction."""
+
+    def test_tags_sorted_alphabetically(self):
+        ss = SearchState(scope='all', sort='age-desc',
+                         tags='zebra,apple,mango')
+        self.assertEqual(ss.tags, ['apple', 'mango', 'zebra'])
+
+    def test_already_sorted_unchanged(self):
+        ss = SearchState(scope='all', sort='age-desc',
+                         tags='apple,mango,zebra')
+        self.assertEqual(ss.tags, ['apple', 'mango', 'zebra'])
+
+    def test_duplicates_removed_then_sorted(self):
+        ss = SearchState(scope='all', sort='age-desc',
+                         tags='zebra,apple,zebra,mango')
+        self.assertEqual(ss.tags, ['apple', 'mango', 'zebra'])
+
+    def test_query_string_uses_sorted_tags(self):
+        ss = SearchState(scope='all', sort='age-desc',
+                         tags='zebra,apple,mango')
+        self.assertIn('tags:apple,mango,zebra', ss.query_string())
+
+    def test_no_tags_no_change(self):
+        ss = SearchState(scope='all', sort='age-desc', tags=None)
+        self.assertEqual(ss.tags, [])
+
+
+class CanonicalUrlRedirectTests(AskbotTestCase):
+    """questions() view should 301-redirect unsorted tag URLs."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def _get(self, path, **kwargs):
+        request = self.factory.get(path)
+        request.user = AnonymousUser()
+        return questions_view(request, **kwargs)
+
+    def test_unsorted_tags_redirect_301(self):
+        """An unsorted tag URL should 301 to the sorted-tag canonical URL."""
+        response = self._get(
+            '/questions/scope:all/sort:age-desc/tags:zebra,apple,mango/',
+            scope='all', sort='age-desc', tags='zebra,apple,mango'
+        )
+        self.assertEqual(response.status_code, 301)
+        self.assertIn('tags:apple,mango,zebra', response['Location'])
+
+    def test_sorted_tags_no_redirect(self):
+        """An already-canonical URL should be served, not redirected."""
+        response = self._get(
+            '/questions/scope:all/sort:age-desc/tags:apple,mango,zebra/page:1/',
+            scope='all', sort='age-desc', tags='apple,mango,zebra'
+        )
+        # 200 or other content response, not a 301 redirect
+        self.assertNotEqual(response.status_code, 301)
+
+    def test_bare_questions_url_no_redirect(self):
+        """The bare /questions/ URL has no tags; should not redirect."""
+        response = self._get('/questions/')
+        self.assertNotEqual(response.status_code, 301)
+
+    def test_non_tag_filter_no_redirect(self):
+        """A scope+sort URL without tags should not redirect."""
+        response = self._get(
+            '/questions/scope:unanswered/sort:age-desc/',
+            scope='unanswered', sort='age-desc'
+        )
+        self.assertNotEqual(response.status_code, 301)
+
+    def test_redirect_preserves_other_params(self):
+        """Redirect should carry through scope, sort, page parameters."""
+        response = self._get(
+            '/questions/scope:unanswered/sort:votes-desc/tags:c,a,b/page:3/',
+            scope='unanswered', sort='votes-desc', tags='c,a,b', page='3'
+        )
+        self.assertEqual(response.status_code, 301)
+        location = response['Location']
+        self.assertIn('scope:unanswered', location)
+        self.assertIn('sort:votes-desc', location)
+        self.assertIn('tags:a,b,c', location)
+        self.assertIn('page:3', location)
+
+    def test_duplicate_tags_redirected_to_deduped_sorted(self):
+        """URL with duplicate tags should redirect to deduped sorted URL."""
+        response = self._get(
+            '/questions/scope:all/sort:age-desc/tags:b,a,b,c/',
+            scope='all', sort='age-desc', tags='b,a,b,c'
+        )
+        self.assertEqual(response.status_code, 301)
+        self.assertIn('tags:a,b,c', response['Location'])

--- a/askbot/tests/test_search_state.py
+++ b/askbot/tests/test_search_state.py
@@ -285,8 +285,10 @@ class SearchStateTests(AskbotTestCase):
             page=None,
             user_logged_in=False
         )
+        # Tags are deduplicated AND sorted alphabetically for canonical URLs
+        # (collapses N! permutations into one cacheable URL).
         self.assertEqual(
-            'scope:all/sort:activity-desc/tags:valid1,dupped,valid2/page:1/',
+            'scope:all/sort:activity-desc/tags:dupped,valid1,valid2/page:1/',
             ss.query_string()
         )
 

--- a/askbot/views/readers.py
+++ b/askbot/views/readers.py
@@ -13,6 +13,7 @@ import operator
 from django.shortcuts import get_object_or_404
 from django.shortcuts import render
 from django.http import HttpResponseRedirect
+from django.http import HttpResponsePermanentRedirect
 from django.http import HttpResponse
 from django.http import Http404
 from django.http import HttpResponseNotAllowed
@@ -87,6 +88,19 @@ def questions(request, **kwargs):
                     user_logged_in=request.user.is_authenticated,
                     **kwargs
                 )
+
+    # Canonicalize tag order: redirect /tags:c,a,b/ -> /tags:a,b,c/.
+    # Without this, every permutation of the same tag set is a distinct URL
+    # serving identical content, which fragments caches and is exploited by
+    # scrapers that enumerate tag orderings to bypass per-URL caching.
+    # Only redirects when tags are present and unsorted; doesn't touch the
+    # bare /questions/ URL or other parameter shapes.
+    raw_tags = kwargs.get('tags')
+    if (raw_tags and request.method == 'GET' and not is_ajax(request)
+            and search_state.tags
+            and raw_tags.split(const.TAG_SEP) != search_state.tags):
+        canonical_path = reverse('questions') + search_state.query_string()
+        return HttpResponsePermanentRedirect(canonical_path)
 
     qs, meta_data = models.Thread.objects.run_advanced_search(
                         request_user=request.user, search_state=search_state


### PR DESCRIPTION
Without this, every permutation of the same tag set is a distinct URL serving identical content, which fragments caches and is exploited by distributed scrapers that enumerate tag orderings to bypass per-URL caching. With 7-8 tag sets this multiplies one underlying page into N! variant URLs.

Production data (2026-05-09): a botnet of ~18k unique IPs (single fake Chrome 125 UA) hit 5,240 distinct orderings of one 8-tag set in 6 hours. Real users use 1-3 tags; 4+ tags is bot-only behavior (98% of hits).

Fix: SearchState.__init__ sorts self.tags alphabetically after dedup, so query_string() yields the canonical form. The questions() view checks the raw URL tags param against the sorted tags and 301-redirects when they differ. N! permutations collapse to one cacheable URL.

Tests: 11 new tests in test_canonical_urls.py covering SearchState sorting and view-level redirect behavior. Updated one expectation in test_search_state.py::test_prevent_dupped_tags (asserted the old non-canonical output).