### PR TITLE
Don't cache answer form across users (CSRF token leak)

### DIFF
--- a/askbot/views/readers.py
+++ b/askbot/views/readers.py
@@ -638,6 +638,15 @@ def question(request, id):#refactor - long subroutine. display question body, an
     is_cacheable = True
     if show_page != 1:
         is_cacheable = False
+    elif request.user.is_authenticated:
+        # The cached fragment includes the answer form with {{ csrf_input }}.
+        # The cache key is only thread.id, so caching across users would serve
+        # one user's CSRF token to everyone else, causing 403s on submit.
+        # Authenticated users also have other personalized content (drafts,
+        # vote buttons, permission-gated controls), so the fragment cache is
+        # never safe for them. Anonymous users still benefit from the cache,
+        # which is the main scraper-defense use case.
+        is_cacheable = False
     # temporary, until invalidation fix. Got broken with Python 3
     # elif show_comment_position > askbot_settings.MAX_COMMENTS_TO_SHOW:
     #    is_cacheable = False


### PR DESCRIPTION
Not sure if I'm confused but adding answers/etc was completely broken on our site without this change.  I'm not seeing how that was a configuration, but maybe it was and/or I'm getting confused by changes we made previously.  If bogus, please ignore; I'm hoping it'll be obvious to you.

--

The question detail template wraps thread content in {% cache long_time "thread-content-html" thread.id %} and that block includes new_answer_form.html, which embeds {{ csrf_input }}. The cache key is only thread.id, so one user's CSRF token gets cached and served to every other user. When a different user submits the form, their _csrf cookie's secret doesn't match the form's masked secret and the request is rejected with "CSRF token from POST incorrect" -> 403.

The fragment also includes other authenticated-user-specific content (draft answers, vote buttons, permission-gated controls), so a key of just thread.id is fundamentally unsafe for authenticated users.

Fix: extend the is_cacheable predicate to also be False when request.user.is_authenticated. Anonymous users still benefit from the cache, which is the primary scraper-defense use case for this fragment on high-traffic question pages.

Reproduced on production ask.wingware.com 2026-05-20: an anon user populated the cache entry without the form, then a logged-in user loaded the page (got the cached fragment from a different prior logged-in render whose CSRF token differed) and consistently got 403 on submit. With this fix the issue goes away immediately after flushing Redis.